### PR TITLE
[#6] Check for usage of 'head' for lists

### DIFF
--- a/src/Stan.hs
+++ b/src/Stan.hs
@@ -7,8 +7,8 @@ Main running module.
 -}
 
 module Stan
-       ( runStan
-       ) where
+    ( runStan
+    ) where
 
 -- import Text.Pretty.Simple (pPrint)
 
@@ -23,5 +23,4 @@ runStan = runStanCli >>= \CliArgs{..} -> do
     let analysis = runAnalysis hieFiles
     print analysis
 
-    -- for debugging
-    -- whenNotNull hieFiles $ pPrint . head
+    -- debugHieFile "app/Main.hs" hieFiles

--- a/src/Stan/Analysis/Partial.hs
+++ b/src/Stan/Analysis/Partial.hs
@@ -27,7 +27,9 @@ import qualified Data.Map.Strict as Map
 -}
 analyseForHeadObservations :: HieFile -> [Observation]
 analyseForHeadObservations HieFile{..} =
-    map mkPartialObservation $ findHeads hie_asts
+    map (uncurry mkPartialObservation)
+    $ zip [1..]
+    $ findHeads hie_asts
   where
     findHeads :: HieASTs TypeIndex -> [RealSrcSpan]
     findHeads =
@@ -63,10 +65,11 @@ analyseForHeadObservations HieFile{..} =
 
         pure srcSpan
 
-    mkPartialObservation :: RealSrcSpan -> Observation
-    mkPartialObservation srcSpan = Observation
-        { observationId = Id ""  -- TODO: how to create observation id?
-        , observationInspectionId = Id "HEAD"
+    mkPartialObservation :: Int -> RealSrcSpan -> Observation
+    mkPartialObservation num srcSpan = Observation
+        -- TODO: See issue #26: https://github.com/kowainik/stan/issues/26
+        { observationId = Id $ show num <> "-STAN-0001-HEAD"
+        , observationInspectionId = Id "STAN-0001-HEAD"
         , observationLoc = srcSpan
         , observationFile = hie_hs_file
         }

--- a/src/Stan/Analysis/Partial.hs
+++ b/src/Stan/Analysis/Partial.hs
@@ -1,0 +1,72 @@
+{- |
+Copyright: (c) 2020 Kowainik
+SPDX-License-Identifier: MPL-2.0
+Maintainer: Kowainik <xrom.xkov@gmail.com>
+
+Static analysis checks for partial functions.
+-}
+
+module Stan.Analysis.Partial
+    ( analyseForHeadObservations
+    ) where
+
+import HieTypes (HieAST (..), HieASTs (..), HieFile (..), Identifier, IdentifierDetails (..),
+                 NodeInfo (..), TypeIndex)
+import Module (moduleName, moduleNameString, moduleUnitId)
+import Name (nameModule, nameOccName)
+import OccName (occNameString)
+import SrcLoc (RealSrcSpan)
+
+import Stan.Core.Id (Id (..))
+import Stan.Observation (Observation (..))
+
+import qualified Data.Map.Strict as Map
+
+
+{- | Check for occurrences of the partial @head@ function.
+-}
+analyseForHeadObservations :: HieFile -> [Observation]
+analyseForHeadObservations HieFile{..} =
+    map mkPartialObservation $ findHeads hie_asts
+  where
+    findHeads :: HieASTs TypeIndex -> [RealSrcSpan]
+    findHeads =
+        concatMap findInAst
+        . Map.elems
+        . getAsts
+
+    findInAst :: HieAST TypeIndex -> [RealSrcSpan]
+    findInAst Node{..} =
+        findInNode nodeSpan nodeInfo ++ concatMap findInAst nodeChildren
+
+    findInNode :: RealSrcSpan -> NodeInfo TypeIndex -> [RealSrcSpan]
+    findInNode srcSpan NodeInfo{..} =
+        mapMaybe (findHeadUsage srcSpan)
+        $ Map.assocs nodeIdentifiers
+
+    findHeadUsage
+        :: RealSrcSpan
+        -> (Identifier, IdentifierDetails TypeIndex)
+        -> Maybe RealSrcSpan
+    findHeadUsage srcSpan (identifier, _details) = do
+        Right name <- Just identifier
+
+        let occName = occNameString $ nameOccName name
+        let modul = moduleNameString $ moduleName $ nameModule name
+        let package = show @String $ moduleUnitId $ nameModule name
+
+        guard $ and
+            [ occName == "head"
+            , modul   == "GHC.List"
+            , package == "base"
+            ]
+
+        pure srcSpan
+
+    mkPartialObservation :: RealSrcSpan -> Observation
+    mkPartialObservation srcSpan = Observation
+        { observationId = Id ""  -- TODO: how to create observation id?
+        , observationInspectionId = Id "HEAD"
+        , observationLoc = srcSpan
+        , observationFile = hie_hs_file
+        }

--- a/src/Stan/Cli.hs
+++ b/src/Stan/Cli.hs
@@ -18,8 +18,8 @@ import Colourista (blue, bold, formatWith)
 import Data.Version (showVersion)
 import Development.GitRev (gitCommitDate, gitHash)
 import Options.Applicative (Parser, ParserInfo, execParser, fullDesc, help, helper, info,
-                            infoOption, long, long, metavar, progDesc, short, showDefault,
-                            strOption, value)
+                            infoOption, long, metavar, progDesc, short, showDefault, strOption,
+                            value)
 
 import qualified Paths_stan as Meta (version)
 
@@ -27,7 +27,6 @@ import qualified Paths_stan as Meta (version)
 newtype CliArgs = CliArgs
     { cliArgsHiedir :: FilePath  -- ^ Directory with HIE files
     }
-
 
 -- | Run main parser of the @stan@ command line tool.
 runStanCli :: IO CliArgs

--- a/src/Stan/Hie/Debug.hs
+++ b/src/Stan/Hie/Debug.hs
@@ -19,7 +19,8 @@ package to dependencies and use the @pPrint@ function from the
 -}
 
 module Stan.Hie.Debug
-    ( printHieAsts
+    ( debugHieFile
+    , printHieAsts
     ) where
 
 import Avail (AvailInfo (..))
@@ -36,9 +37,16 @@ import Module (Module, ModuleName, moduleNameString, moduleStableString)
 import Name (Name, nameStableString)
 import Outputable (CodeStyle (CStyle), mkCodeStyle, printSDocLn)
 import Pretty (Mode (PageMode))
+import Text.Pretty.Simple (pPrint)
 import Var (ArgFlag (..))
 
 import qualified Text.Show
+
+
+debugHieFile :: FilePath -> [HieFile] -> IO ()
+debugHieFile path hieFiles = do
+    let mHieFile = find (\HieFile{..} -> hie_hs_file == path) hieFiles
+    whenJust mHieFile pPrint
 
 {- | Prints 'HieASTs' part of 'HieFile' using @ghc@ pretty-printing.
 -}

--- a/src/Stan/Inspection.hs
+++ b/src/Stan/Inspection.hs
@@ -53,15 +53,17 @@ prettyShowInspection = show
 inspections :: [Inspection]
 inspections =
     [ Inspection
-        { inspectionId = Id "HEAD"  -- TODO: we need to come up with naming scheme for inspection ids
-        , inspectionName = "Partial 'head'"  -- TODO: does it make sense?
+        -- TODO: See issue #26: https://github.com/kowainik/stan/issues/26
+        { inspectionId = Id "STAN-0001-HEAD"
+        , inspectionName = "Partial: base/head"
         , inspectionDescription = "Usage of partial function 'head' for lists"
         , inspectionSolution = unlines
             [ "* Replace list with 'NonEmpty' from 'Data.List.NonEmpty'"
             , "* Use explicit pattern-matching over lists"
             ]
         , inspectionCategory =
-            one $ Category "Partial"  -- TODO: should we convert this to values to avoid typos?
+            -- TODO: See issue #25: https://github.com/kowainik/stan/issues/25
+            one $ Category "Partial"
         , inspectionSeverity = Severe
         }
     ]

--- a/src/Stan/Inspection.hs
+++ b/src/Stan/Inspection.hs
@@ -11,11 +11,13 @@ module Stan.Inspection
     , Category (..)
     , Severity (..)
 
+    , inspections
+
       -- * Pretty print
     , prettyShowInspection
     ) where
 
-import Stan.Core.Id (Id)
+import Stan.Core.Id (Id (..))
 
 
 {- | Data type that represents a check/test, or how we call it
@@ -45,3 +47,21 @@ data Severity
 -- | Show 'Inspection' in a human-friendly format.
 prettyShowInspection :: Inspection -> Text
 prettyShowInspection = show
+
+{- | List of all inspections.
+-}
+inspections :: [Inspection]
+inspections =
+    [ Inspection
+        { inspectionId = Id "HEAD"  -- TODO: we need to come up with naming scheme for inspection ids
+        , inspectionName = "Partial 'head'"  -- TODO: does it make sense?
+        , inspectionDescription = "Usage of partial function 'head' for lists"
+        , inspectionSolution = unlines
+            [ "* Replace list with 'NonEmpty' from 'Data.List.NonEmpty'"
+            , "* Use explicit pattern-matching over lists"
+            ]
+        , inspectionCategory =
+            one $ Category "Partial"  -- TODO: should we convert this to values to avoid typos?
+        , inspectionSeverity = Severe
+        }
+    ]

--- a/src/Stan/Observation.hs
+++ b/src/Stan/Observation.hs
@@ -13,7 +13,7 @@ module Stan.Observation
     , prettyShowObservation
     ) where
 
-import GHC (SrcSpan)
+import SrcLoc (RealSrcSpan)
 
 import Stan.Core.Id (Id)
 import Stan.Inspection (Inspection)
@@ -24,7 +24,8 @@ import Stan.Inspection (Inspection)
 data Observation = Observation
     { observationId           :: !(Id Observation)
     , observationInspectionId :: !(Id Inspection)
-    , observationLoc          :: !SrcSpan
+    , observationLoc          :: !RealSrcSpan
+    , observationFile         :: !FilePath
     } deriving stock (Show)
 
 -- | Show 'Observation' in a human-friendly format.

--- a/stan.cabal
+++ b/stan.cabal
@@ -72,6 +72,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     Stan
                          Stan.Analysis
+                           Stan.Analysis.Partial
                          Stan.Cli
                          Stan.Core.Id
                          Stan.Hie
@@ -84,6 +85,7 @@ library
 
   build-depends:       bytestring ^>= 0.10
                      , colourista ^>= 0.0.0.0
+                     , containers ^>= 0.6
                      , dir-traverse ^>= 0.2.2.2
                      , directory ^>= 1.3
                      , filepath ^>= 1.4
@@ -91,9 +93,7 @@ library
                      , ghc-paths ^>= 0.1.0.12
                      , gitrev ^>= 1.3.1
                      , optparse-applicative ^>= 0.15
-
---                       Uncomment for debugging
---                     , pretty-simple ^>= 3.2
+                     , pretty-simple ^>= 3.2
 
 executable stan
   import:              common-options

--- a/test/Test/Analysis.hs
+++ b/test/Test/Analysis.hs
@@ -17,4 +17,4 @@ linesOfCodeSpec hieFile = describe "LoC tests" $
 modulesNumSpec :: Int -> Spec
 modulesNumSpec num = describe "Modules number tests" $
     it "should count correct number of modules" $
-        num `shouldBe` 12
+        num `shouldBe` 13


### PR DESCRIPTION
Resolves #6

It worked! On my local test case I saw this output:

```haskell
Analysis
    { analysisModuleCount = 12
    , analysisLinesOfCode = 0
    , analysisUsedExtensions = 0
    , analysisObservations =
        [ Observation
            { observationId = Id {unId = ""}
            , observationInspectionId = Id {unId = "HEAD"}
            , observationLoc = SrcSpanOneLine "app/Main.hs" 7 7 21
            , observationFile = "app/Main.hs"
            }
        ]
    }
```