### PR TITLE
[#53] Don't find identifier usages in imports

### DIFF
--- a/src/Stan.hs
+++ b/src/Stan.hs
@@ -10,12 +10,11 @@ module Stan
     ( runStan
     ) where
 
--- import Text.Pretty.Simple (pPrint)
-
 import Stan.Analysis (runAnalysis)
 import Stan.Analysis.Pretty (prettyShowAnalysis)
 import Stan.Cli (CliArgs (..), runStanCli)
 import Stan.Hie (readHieFiles)
+-- import Stan.Hie.Debug (debugHieFile)
 
 
 runStan :: IO ()
@@ -24,4 +23,4 @@ runStan = runStanCli >>= \CliArgs{..} -> do
     let analysis = runAnalysis hieFiles
     putTextLn $ prettyShowAnalysis analysis
 
-    -- debugHieFile "app/Main.hs" hieFiles
+--    debugHieFile "target/Target/Infinite.hs" hieFiles

--- a/src/Stan/Analysis/Analyser.hs
+++ b/src/Stan/Analysis/Analyser.hs
@@ -11,8 +11,8 @@ module Stan.Analysis.Analyser
     , mkNameMetaAnalyser
     ) where
 
-import HieTypes (HieAST (..), HieASTs (..), HieFile (..), Identifier, IdentifierDetails (..),
-                 NodeInfo (..), TypeIndex)
+import HieTypes (ContextInfo (..), HieAST (..), HieASTs (..), HieFile (..), IEType (..), Identifier,
+                 IdentifierDetails (..), NodeInfo (..), TypeIndex)
 import Module (moduleName, moduleNameString, moduleUnitId)
 import Name (nameModule, nameOccName)
 import OccName (occNameString)
@@ -24,6 +24,7 @@ import Stan.NameMeta (NameMeta (..))
 import Stan.Observation (Observation, mkObservation)
 
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 
 
 {- | Contains analyser function to run on 'HieFile's.
@@ -69,8 +70,9 @@ analyseNameMeta insId NameMeta{..} hie@HieFile{..} =
         :: RealSrcSpan
         -> (Identifier, IdentifierDetails TypeIndex)
         -> Maybe RealSrcSpan
-    findHeadUsage srcSpan (identifier, _details) = do
+    findHeadUsage srcSpan (identifier, details) = do
         Right name <- Just identifier
+        guard $ Set.notMember (IEThing Import) $ identInfo details
 
         let occName = occNameString $ nameOccName name
         let modul = moduleNameString $ moduleName $ nameModule name

--- a/test/Test/Stan/Analysis/Infinite.hs
+++ b/test/Test/Stan/Analysis/Infinite.hs
@@ -19,9 +19,7 @@ analysisInfiniteSpec analysis = describe "Partial functions" $ do
 
     it "STAN-0101: finds usage of 'base/reverse'" $
         checkObservation analysis Infinite.stan0101 9 15 22
-    -- TODO: this is incorrect, it finds in import
     it "STAN-0102: finds usage of 'base/isSuffixOf'" $
-        checkObservation analysis Infinite.stan0102 5 34 44
-    -- TODO: this is incorrect, it finds in import
+        checkObservation analysis Infinite.stan0102 12 18 28
     it "STAN-0103: finds usage of 'base/genericLength'" $
-        checkObservation analysis Infinite.stan0103 5 19 32
+        checkObservation analysis Infinite.stan0103 15 21 34


### PR DESCRIPTION
Resolves #53

AST node looks like this:

```haskell
, nodeIdentifiers = fromList
    [
        ( Right $base$Data.OldList$genericLength
        , IdentifierDetails
            { identType = Nothing
            , identInfo = fromList [ IEThing Import ]
            }
        )
    ]
```

Each identifier contains a `Set` of some [`ContextInfo`](https://downloads.haskell.org/~ghc/8.8.3/docs/html/libraries/ghc-8.8.3/HieTypes.html#t:ContextInfo). So I'm just checking that this name doesn't come under the `Import` context.