### PR TITLE
[#32] Stable ids for Observations

### DIFF
--- a/src/Stan/Analysis/Analyser.hs
+++ b/src/Stan/Analysis/Analyser.hs
@@ -49,7 +49,7 @@ analyseNameMeta
   -> HieFile
   -> [Observation]
 analyseNameMeta insId NameMeta{..} hie@HieFile{..} =
-    zipWith (mkObservation insId hie) [1..] $ findHeads hie_asts
+    map (mkObservation insId hie) $ findHeads hie_asts
   where
     findHeads :: HieASTs TypeIndex -> [RealSrcSpan]
     findHeads =

--- a/stan.cabal
+++ b/stan.cabal
@@ -95,9 +95,11 @@ library
   autogen-modules:     Paths_stan
   other-modules:       Paths_stan
 
-  build-depends:       bytestring ^>= 0.10
+  build-depends:       base64 ^>= 0.4.1
+                     , bytestring ^>= 0.10
                      , colourista ^>= 0.0.0.0
                      , containers ^>= 0.6
+                     , cryptohash-sha1 ^>= 0.11
                      , dir-traverse ^>= 0.2.2.2
                      , directory ^>= 1.3
                      , filepath ^>= 1.4
@@ -132,6 +134,7 @@ test-suite stan-test
                          Test.Stan.Analysis.Partial
                        Test.Stan.Inspection
                        Test.Stan.Number
+                       Test.Stan.Observation
 
   build-depends:       stan
                      , filepath ^>= 1.4

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -7,6 +7,7 @@ import Stan.Hie (readHieFiles)
 import Test.Stan.Analysis (analysisSpec)
 import Test.Stan.Inspection (inspectionsSpec)
 import Test.Stan.Number (linesOfCodeSpec, modulesNumSpec)
+import Test.Stan.Observation (observationSpec)
 
 
 main :: IO ()
@@ -23,6 +24,7 @@ main = do
                 linesOfCodeSpec exampleHie
                 modulesNumSpec $ length hieFiles
                 inspectionsSpec
+                observationSpec
                 analysisSpec testHies
 
 isTargetFile :: HieFile -> Bool

--- a/test/Test/Stan/Analysis/Common.hs
+++ b/test/Test/Stan/Analysis/Common.hs
@@ -3,7 +3,7 @@ module Test.Stan.Analysis.Common
     ) where
 
 import FastString (FastString, mkFastString)
-import SrcLoc (mkRealSrcLoc, mkRealSrcSpan)
+import SrcLoc (RealSrcSpan, mkRealSrcLoc, mkRealSrcSpan)
 import System.FilePath ((</>))
 import Test.Hspec (Expectation, shouldBe)
 
@@ -16,14 +16,13 @@ import Stan.Observation (Observation (..), mkObservationId)
 observationSpec
     :: FilePath  -- ^ Path to module
     -> Text  -- ^ Module name
-    -> Int  -- ^ 'Observation' number
     -> Analysis
     -> Id Inspection
     -> Int  -- ^ Line number
     -> Int  -- ^ Span start
     -> Int  -- ^ Span end
     -> Expectation
-observationSpec modulePath moduleName num analysis insId line start end =
+observationSpec modulePath moduleName analysis insId line start end =
     foundPartialObservation `shouldBe` Just expectedHeadObservation
   where
     foundPartialObservation :: Maybe Observation
@@ -35,16 +34,19 @@ observationSpec modulePath moduleName num analysis insId line start end =
     expectedHeadObservation = Observation
         { observationId = obsId
         , observationInspectionId = insId
-        , observationLoc = mkRealSrcSpan
-            (mkRealSrcLoc pathFS line start)
-            (mkRealSrcLoc pathFS line end)
+        , observationLoc = span
         , observationFile = path
         , observationModuleName = moduleName
         , observationFileContent = maybe "" observationFileContent foundPartialObservation
         }
 
     obsId :: Id Observation
-    obsId = mkObservationId num insId
+    obsId = mkObservationId insId moduleName span
+
+    span :: RealSrcSpan
+    span = mkRealSrcSpan
+        (mkRealSrcLoc pathFS line start)
+        (mkRealSrcLoc pathFS line end)
 
     path :: FilePath
     path = "target" </> modulePath

--- a/test/Test/Stan/Analysis/Common.hs
+++ b/test/Test/Stan/Analysis/Common.hs
@@ -1,5 +1,5 @@
 module Test.Stan.Analysis.Common
-    ( observationSpec
+    ( observationAssert
     ) where
 
 import FastString (FastString, mkFastString)
@@ -13,7 +13,7 @@ import Stan.Inspection (Inspection)
 import Stan.Observation (Observation (..), mkObservationId)
 
 
-observationSpec
+observationAssert
     :: FilePath  -- ^ Path to module
     -> Text  -- ^ Module name
     -> Analysis
@@ -22,7 +22,7 @@ observationSpec
     -> Int  -- ^ Span start
     -> Int  -- ^ Span end
     -> Expectation
-observationSpec modulePath moduleName analysis insId line start end =
+observationAssert modulePath moduleName analysis insId line start end =
     foundPartialObservation `shouldBe` Just expectedHeadObservation
   where
     foundPartialObservation :: Maybe Observation

--- a/test/Test/Stan/Analysis/Infinite.hs
+++ b/test/Test/Stan/Analysis/Infinite.hs
@@ -5,14 +5,14 @@ module Test.Stan.Analysis.Infinite
 import Test.Hspec (Spec, describe, it)
 
 import Stan.Analysis (Analysis)
-import Test.Stan.Analysis.Common (observationSpec)
+import Test.Stan.Analysis.Common (observationAssert)
 
 import qualified Stan.Inspection.Infinite as Infinite
 
 
 analysisInfiniteSpec :: Analysis -> Spec
 analysisInfiniteSpec analysis = describe "Partial functions" $ do
-    let checkObservation = observationSpec
+    let checkObservation = observationAssert
             "Target/Infinite.hs"
             "Target.Infinite"
 

--- a/test/Test/Stan/Analysis/Infinite.hs
+++ b/test/Test/Stan/Analysis/Infinite.hs
@@ -15,7 +15,6 @@ analysisInfiniteSpec analysis = describe "Partial functions" $ do
     let checkObservation = observationSpec
             "Target/Infinite.hs"
             "Target.Infinite"
-            1
 
     it "STAN-0101: finds usage of 'base/reverse'" $
         checkObservation analysis Infinite.stan0101 9 15 22

--- a/test/Test/Stan/Analysis/Partial.hs
+++ b/test/Test/Stan/Analysis/Partial.hs
@@ -5,14 +5,14 @@ module Test.Stan.Analysis.Partial
 import Test.Hspec (Spec, describe, it)
 
 import Stan.Analysis (Analysis)
-import Test.Stan.Analysis.Common (observationSpec)
+import Test.Stan.Analysis.Common (observationAssert)
 
 import qualified Stan.Inspection.Partial as Partial
 
 
 analysisPartialSpec :: Analysis -> Spec
 analysisPartialSpec analysis = describe "Partial functions" $ do
-    let checkObservation = observationSpec
+    let checkObservation = observationAssert
             "Target/Partial.hs"
             "Target.Partial"
 

--- a/test/Test/Stan/Analysis/Partial.hs
+++ b/test/Test/Stan/Analysis/Partial.hs
@@ -15,7 +15,6 @@ analysisPartialSpec analysis = describe "Partial functions" $ do
     let checkObservation = observationSpec
             "Target/Partial.hs"
             "Target.Partial"
-            1
 
     it "STAN-0001: finds usage of 'base/head'" $
         checkObservation analysis Partial.stan0001 7 12 16

--- a/test/Test/Stan/Number.hs
+++ b/test/Test/Stan/Number.hs
@@ -17,4 +17,4 @@ linesOfCodeSpec hieFile = describe "LoC tests" $
 modulesNumSpec :: Int -> Spec
 modulesNumSpec num = describe "Modules number tests" $
     it "should count correct number of modules" $
-        num `shouldBe` 28
+        num `shouldBe` 29

--- a/test/Test/Stan/Observation.hs
+++ b/test/Test/Stan/Observation.hs
@@ -1,0 +1,24 @@
+module Test.Stan.Observation
+    ( observationSpec
+    ) where
+
+import SrcLoc (mkRealSrcLoc, mkRealSrcSpan)
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+import Stan.Core.Id (Id (..))
+import Stan.Inspection.Partial (stan0001)
+import Stan.Observation (Observation, mkObservationId)
+
+
+observationSpec :: Spec
+observationSpec = describe "Observation" $
+    it "calculates Observation Id properly" $
+        testObservationId `shouldBe` Id "OBS-STAN-0001-bbjjJQ-10:42"
+  where
+    testObservationId :: Id Observation
+    testObservationId = mkObservationId
+        stan0001
+        "Test.Module.Name"
+        $ mkRealSrcSpan
+            (mkRealSrcLoc "src/Test/Module/Name.hs" 10 42)
+            (mkRealSrcLoc "src/Test/Module/Name.hs" 10 42)


### PR DESCRIPTION
Resolves #32

Now Observation ID looks like this:

![Screenshot from 2020-04-20 20-06-13](https://user-images.githubusercontent.com/4276606/79789723-8cb56600-8342-11ea-9add-9c40772877a1.png)
