### PR TITLE
[#38] Add partial inspections for 'fromJust' and 'read'

### DIFF
--- a/src/Stan/Inspection/Partial.hs
+++ b/src/Stan/Inspection/Partial.hs
@@ -22,6 +22,10 @@ module Stan.Inspection.Partial
     , stan0006
       -- *** Partial 'Data.OldList.genericIndex'
     , stan0007
+      -- *** Partial 'Data.Maybe.fromJust'
+    , stan0008
+      -- *** Partial 'Text.Read.read'
+    , stan0009
 
       -- * List of all partial 'Inspection's
     , partialInspectionsMap
@@ -46,6 +50,8 @@ partialInspectionsMap = fromList $ map (mapToFst inspectionId)
     , stan0005
     , stan0006
     , stan0007
+    , stan0008
+    , stan0009
     ]
 
 -- | Smart constructor to create partial 'Inspection'.
@@ -98,3 +104,46 @@ stan0006 = mkPartialInspectionList (Id "STAN-0006") (mkBaseListMeta "cycle")
 -- | 'Inspection' for 'stan0007' — partial 'Data.OldList.genericIndex' @STAN-0007@.
 stan0007 :: Inspection
 stan0007 = mkPartialInspection (Id "STAN-0007") (mkBaseOldListMeta "genericIndex")
+
+-- | 'Inspection' for 'stan0008' — partial 'Data.Maybe.fromJust' @STAN-0008@.
+stan0008 :: Inspection
+stan0008 = Inspection
+    { inspectionId = Id "STAN-0008"
+    , inspectionName = "Partial: " <> nameMetaPackage <> "/" <> nameMetaName
+    , inspectionDescription = "Usage of partial function '" <> nameMetaName <> "' for 'Maybe'"
+    , inspectionSolution =
+        [ "Use explicit pattern-matching over Maybe"
+        , "Use one of the standard functions: 'maybe', 'fromMaybe'"
+        ]
+    , inspectionCategory = one partial
+    , inspectionSeverity = Warning
+    , inspectionAnalysis = FindName nameMeta
+    }
+  where
+    nameMeta :: NameMeta
+    nameMeta@NameMeta{..} = NameMeta
+        { nameMetaName       = "fromJust"
+        , nameMetaModuleName = "Data.Maybe"
+        , nameMetaPackage    = "base"
+        }
+
+-- | 'Inspection' for 'stan0008' — partial 'Data.Maybe.fromJust' @STAN-0008@.
+stan0009 :: Inspection
+stan0009 = Inspection
+    { inspectionId = Id "STAN-0009"
+    , inspectionName = "Partial: " <> nameMetaPackage <> "/" <> nameMetaName
+    , inspectionDescription = "Usage of partial parsing function '" <> nameMetaName <> "'"
+    , inspectionSolution =
+        [ "Use 'readMaybe' or 'readEither' to handle failed parsing"
+        ]
+    , inspectionCategory = one partial
+    , inspectionSeverity = Warning
+    , inspectionAnalysis = FindName nameMeta
+    }
+  where
+    nameMeta :: NameMeta
+    nameMeta@NameMeta{..} = NameMeta
+        { nameMetaName       = "read"
+        , nameMetaModuleName = "Text.Read"
+        , nameMetaPackage    = "base"
+        }

--- a/target/Target/Partial.hs
+++ b/target/Target/Partial.hs
@@ -3,6 +3,7 @@
 module Target.Partial where
 
 import Data.List (genericIndex)
+import Data.Maybe (fromJust)
 
 
 stanHead :: [a] -> a
@@ -25,3 +26,9 @@ stanCycle = cycle
 
 stanGenericIndex :: [a] -> Int -> a
 stanGenericIndex = genericIndex
+
+stanFromJust :: Maybe Int -> Int
+stanFromJust = fromJust
+
+stanRead :: String -> Int
+stanRead = read

--- a/test/Test/Stan/Analysis/Partial.hs
+++ b/test/Test/Stan/Analysis/Partial.hs
@@ -17,16 +17,20 @@ analysisPartialSpec analysis = describe "Partial functions" $ do
             "Target.Partial"
 
     it "STAN-0001: finds usage of 'base/head'" $
-        checkObservation analysis Partial.stan0001 9 12 16
+        checkObservation analysis Partial.stan0001 10 12 16
     it "STAN-0002: finds usage of 'base/tail'" $
-        checkObservation analysis Partial.stan0002 12 12 16
+        checkObservation analysis Partial.stan0002 13 12 16
     it "STAN-0003: finds usage of 'base/init'" $
-        checkObservation analysis Partial.stan0003 15 12 16
+        checkObservation analysis Partial.stan0003 16 12 16
     it "STAN-0004: finds usage of 'base/last'" $
-        checkObservation analysis Partial.stan0004 18 12 16
+        checkObservation analysis Partial.stan0004 19 12 16
     it "STAN-0005: finds usage of 'base/!!'" $
-        checkObservation analysis Partial.stan0005 21 16 18
+        checkObservation analysis Partial.stan0005 22 16 18
     it "STAN-0006: finds usage of 'base/cycle'" $
-        checkObservation analysis Partial.stan0006 24 13 18
+        checkObservation analysis Partial.stan0006 25 13 18
     it "STAN-0007: finds usage of 'base/genericIndex'" $
-        checkObservation analysis Partial.stan0007 27 20 32
+        checkObservation analysis Partial.stan0007 28 20 32
+    it "STAN-0008: finds usage of 'base/fromJust'" $
+        checkObservation analysis Partial.stan0008 31 16 24
+    it "STAN-0009: finds usage of 'base/read'" $
+        checkObservation analysis Partial.stan0009 34 12 16

--- a/test/Test/Stan/Number.hs
+++ b/test/Test/Stan/Number.hs
@@ -12,7 +12,7 @@ import Stan.Hie (countLinesOfCode)
 linesOfCodeSpec :: HieFile -> Spec
 linesOfCodeSpec hieFile = describe "LoC tests" $
     it "should count lines of code in the example file" $
-        countLinesOfCode hieFile `shouldBe` 27
+        countLinesOfCode hieFile `shouldBe` 34
 
 modulesNumSpec :: Int -> Spec
 modulesNumSpec num = describe "Modules number tests" $


### PR DESCRIPTION
A few more checks.

The implementation is more verbose this time since data types, modules and solutions are completely different. I'm thinking, that maybe adding lenses to `Inspection` and `NameMeta` data types can help us with reducing boilerplate. What do you think?