### PR TITLE
Count the number of used unique language extensions

### DIFF
--- a/src/Stan.hs
+++ b/src/Stan.hs
@@ -1,3 +1,12 @@
+{-# LANGUAGE CPP , LambdaCase          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+#if __GLASGOW_HASKELL__ < 810
+{-# LANGUAGE TemplateHaskell     #-}
+#else
+{-# LANGUAGE DerivingStrategies  #-}
+#endif
+{-# LANGUAGE TypeApplications    #-}
+
 {- |
 Copyright: (c) 2020 Kowainik
 SPDX-License-Identifier: MPL-2.0
@@ -10,6 +19,10 @@ module Stan
     ( runStan
     ) where
 
+import HeaderInfo (getOptionsFromFile)
+import HieTypes (HieFile (..))
+import Outputable (Outputable (ppr))
+
 import Stan.Analysis (runAnalysis)
 import Stan.Analysis.Pretty (prettyShowAnalysis)
 import Stan.Cli (InspectionArgs (..), StanArgs (..), StanCommand (..), runStanCli)
@@ -18,6 +31,7 @@ import Stan.Hie (readHieFiles)
 import Stan.Inspection (prettyShowInspection, prettyShowInspectionShort)
 import Stan.Inspection.All (inspections, lookupInspectionById)
 -- import Stan.Hie.Debug (debugHieFile)
+import Stan.Hie.Debug (debugDynFlags, printSDoc)
 
 import Colourista (errorMessage, formatWith, italic)
 
@@ -26,6 +40,14 @@ runStan :: IO ()
 runStan = runStanCli >>= \case
     Stan StanArgs{..} -> do
         hieFiles <- readHieFiles stanArgsHiedir
+        case hieFiles of
+            [] -> pass
+            hieFile:_ -> do
+                let f = hie_hs_file hieFile
+                putStrLn $ f <> "###########"
+                dynFlags <- debugDynFlags
+                getOptionsFromFile dynFlags f >>= printSDoc dynFlags . ppr
+
         let analysis = runAnalysis hieFiles
         putTextLn $ prettyShowAnalysis analysis stanArgsToggleSolution
 --        debugHieFile "target/Target/Infinite.hs" hieFiles


### PR DESCRIPTION
Unfortunately, CPP pragmas failing this approach.
This PR is for the demonstration only.

The output for the current run:

```
src/Stan.hs###########
[[-, X, C, P, P], [-, X, L, a, m, b, d, a, C, a, s, e],
 [-, X, S, c, o, p, e, d, T, y, p, e, V, a, r, i, a, b, l, e, s]]
```

While the module contains the following extensions:

```haskell
{-# LANGUAGE CPP , LambdaCase          #-}
{-# LANGUAGE ScopedTypeVariables #-}
#if __GLASGOW_HASKELL__ < 810
{-# LANGUAGE TemplateHaskell     #-}
#else
{-# LANGUAGE DerivingStrategies  #-}
#endif
{-# LANGUAGE TypeApplications    #-}
```

Also, this doesn't take into consideration default extensions coming from the `.cabal` file.