### PR TITLE
[#24] Create configuration

### DIFF
--- a/.stan.toml
+++ b/.stan.toml
@@ -1,0 +1,19 @@
+# ignore everything in the test/ directory
+[[check]]
+type = "Ignore"
+directory = "test/"
+
+[[check]]
+type = "Include"
+
+
+# ignore specific inspection everywhere
+[[check]]
+type = "Ignore"
+inspectionId = "STAN-0002"
+
+# ignore specific inspection only in a specific file
+[[check]]
+type = "Ignore"
+inspectionId = "STAN-0001"
+file = "src/MyFile.hs"

--- a/src/Stan/Config.hs
+++ b/src/Stan/Config.hs
@@ -1,0 +1,55 @@
+{- |
+Copyright: (c) 2020 Kowainik
+SPDX-License-Identifier: MPL-2.0
+Maintainer: Kowainik <xrom.xkov@gmail.com>
+
+@stan@ configurations.
+-}
+
+module Stan.Config
+    ( -- * Data types
+      Config (..)
+    , Check (..)
+    , CheckType (..)
+    , CheckFilter (..)
+    , CheckScope (..)
+    ) where
+
+import Stan.Category (Category (..))
+import Stan.Core.Id (Id (..))
+import Stan.Core.ModuleName (ModuleName (..))
+import Stan.Inspection (Inspection (..))
+import Stan.Observation (Observation (..))
+import Stan.Severity (Severity (..))
+
+
+data Config = Config
+    { configChecks :: ![Check]
+    -- , configGroupBy :: !GroupBy
+    } deriving stock (Show)
+
+data CheckType
+    = Include
+    | Ignore
+    deriving stock (Show, Eq, Enum, Bounded)
+
+-- TODO: it doesn't make sense to have both Nothing, so we need a data type like 'These'
+-- data These a b = This a | That b | Both a b
+data Check = Check
+    { checkType   :: !CheckType
+    , checkFilter :: !(Maybe CheckFilter)
+    , checkScope  :: !(Maybe CheckScope)
+    } deriving stock (Show)
+
+data CheckFilter
+    = CheckInspection (Id Inspection)
+    | CheckObservation (Id Observation)
+    | CheckSeverity Severity
+    | CheckCategory Category
+    deriving stock (Show)
+
+data CheckScope
+    = CheckScopeFile FilePath
+    | CheckScopeDirectory FilePath
+    | CheckScopeModule ModuleName
+    deriving stock (Show)

--- a/src/Stan/Config.hs
+++ b/src/Stan/Config.hs
@@ -33,8 +33,6 @@ data CheckType
     | Ignore
     deriving stock (Show, Eq, Enum, Bounded)
 
--- TODO: it doesn't make sense to have both Nothing, so we need a data type like 'These'
--- data These a b = This a | That b | Both a b
 data Check = Check
     { checkType   :: !CheckType
     , checkFilter :: !(Maybe CheckFilter)

--- a/src/Stan/Severity.hs
+++ b/src/Stan/Severity.hs
@@ -46,7 +46,7 @@ data Severity
     | Warning
     -- | Dangerous behaviour.
     | Error
-    deriving stock (Show, Eq)
+    deriving stock (Show, Eq, Enum, Bounded)
 
 -- | Get the colour of the severity level.
 severityColour :: Severity -> Text

--- a/src/Stan/Toml.hs
+++ b/src/Stan/Toml.hs
@@ -1,0 +1,98 @@
+{- |
+Copyright: (c) 2020 Kowainik
+SPDX-License-Identifier: MPL-2.0
+Maintainer: Kowainik <xrom.xkov@gmail.com>
+
+@tomland@ library integration. 'TomlCodec's for the 'Config' data type.
+-}
+
+module Stan.Toml
+    ( -- * Codecs
+      configCodec
+    ) where
+
+import Toml (Key, TomlCodec, (.=))
+
+import Stan.Category (Category (..))
+import Stan.Config (Check (..), CheckFilter (..), CheckScope (..), CheckType (..), Config (..))
+import Stan.Core.Id (Id (..))
+import Stan.Core.ModuleName (ModuleName (..))
+import Stan.Inspection (Inspection (..))
+import Stan.Observation (Observation (..))
+import Stan.Severity (Severity (..))
+
+import qualified Toml
+
+
+configCodec :: TomlCodec Config
+configCodec = Config
+    <$> Toml.list checkCodec "check" .= configChecks
+
+checkCodec :: TomlCodec Check
+checkCodec = Check
+    <$> checkTypeCodec .= checkType
+    <*> Toml.dioptional checkFilterCodec .= checkFilter
+    <*> Toml.dioptional checkScopeCodec  .= checkScope
+
+checkTypeCodec :: TomlCodec CheckType
+checkTypeCodec = Toml.enumBounded "type"
+
+----------------------------------------------------------------------------
+-- CheckFilter
+----------------------------------------------------------------------------
+
+checkInspection :: CheckFilter -> Maybe (Id Inspection)
+checkInspection = \case
+    CheckInspection idI -> Just idI
+    _ -> Nothing
+
+checkObservation :: CheckFilter -> Maybe (Id Observation)
+checkObservation = \case
+    CheckObservation idO -> Just idO
+    _ -> Nothing
+
+checkSeverity :: CheckFilter -> Maybe Severity
+checkSeverity = \case
+    CheckSeverity sev -> Just sev
+    _ -> Nothing
+
+checkCategory :: CheckFilter -> Maybe Category
+checkCategory = \case
+    CheckCategory category -> Just category
+    _ -> Nothing
+
+checkFilterCodec :: TomlCodec CheckFilter
+checkFilterCodec =
+        Toml.dimatch checkInspection  CheckInspection  (idCodec "inspectionId")
+    <|> Toml.dimatch checkObservation CheckObservation (idCodec "observationId")
+    <|> Toml.dimatch checkSeverity    CheckSeverity    (Toml.enumBounded "severity")
+    <|> Toml.dimatch checkCategory    CheckCategory    (Toml.diwrap (Toml.text "category"))
+
+idCodec :: Key -> TomlCodec (Id a)
+idCodec = Toml.diwrap . Toml.text
+
+----------------------------------------------------------------------------
+-- CheckScope
+----------------------------------------------------------------------------
+
+checkScopeFile :: CheckScope -> Maybe FilePath
+checkScopeFile = \case
+    CheckScopeFile filePath -> Just filePath
+    _ -> Nothing
+
+checkScopeDir :: CheckScope -> Maybe FilePath
+checkScopeDir = \case
+    CheckScopeDirectory dir -> Just dir
+    _ -> Nothing
+
+checkScopeMod :: CheckScope -> Maybe ModuleName
+checkScopeMod = \case
+    CheckScopeModule m -> Just m
+    _ -> Nothing
+
+
+checkScopeCodec :: TomlCodec CheckScope
+checkScopeCodec =
+        Toml.dimatch checkScopeFile CheckScopeFile      (Toml.string "file")
+    <|> Toml.dimatch checkScopeDir  CheckScopeDirectory (Toml.string "directory")
+    <|> Toml.dimatch checkScopeMod  CheckScopeModule    (Toml.diwrap $ Toml.text "module")

--- a/stan.cabal
+++ b/stan.cabal
@@ -79,6 +79,7 @@ library
                            Stan.Analysis.Pretty
                          Stan.Category
                          Stan.Cli
+                         Stan.Config
                          Stan.Core.Id
                          Stan.Core.List
                          Stan.Core.ModuleName
@@ -98,6 +99,7 @@ library
                            Stan.Pattern.Type
                          Stan.Report
                          Stan.Severity
+                         Stan.Toml
 
   autogen-modules:     Paths_stan
   other-modules:       Paths_stan
@@ -119,6 +121,7 @@ library
                      , pretty-simple ^>= 3.2
                      , slist ^>= 0.1
                      , text ^>= 1.2
+                     , tomland ^>= 1.3.0.0
                      , unordered-containers ^>= 0.2
 
 executable stan

--- a/test/Test/Stan/Number.hs
+++ b/test/Test/Stan/Number.hs
@@ -17,4 +17,4 @@ linesOfCodeSpec hieFile = describe "LoC tests" $
 modulesNumSpec :: Int -> Spec
 modulesNumSpec num = describe "Modules number tests" $
     it "should count correct number of modules" $
-        num `shouldBe` 35
+        num `shouldBe` 37


### PR DESCRIPTION
Resolves #24

This PR introduces `Config` data types and TOML codecs.
I will add the logic of reading config and tests separately.

I changed the types a bit in order to preserve the users' order, let me know if it still looks okay, @chshersh 