### PR TITLE
[#120] Create the data type to accumulate and aply config info

### DIFF
--- a/src/Stan/Config.hs
+++ b/src/Stan/Config.hs
@@ -32,6 +32,9 @@ module Stan.Config
 
       -- * Printing
     , configToCliCommand
+
+      -- * Apply config
+    , applyChecks
     ) where
 
 import Trial ((::-), Phase (..), Trial, withTag)
@@ -40,9 +43,12 @@ import Stan.Category (Category (..))
 import Stan.Core.Id (Id (..))
 import Stan.Core.ModuleName (ModuleName (..))
 import Stan.Inspection (Inspection (..))
+import Stan.Inspection.All (inspections, inspectionsIds, lookupInspectionById)
 import Stan.Observation (Observation (..))
 import Stan.Severity (Severity (..))
 
+import qualified Data.HashMap.Strict as HashMap
+import qualified Data.HashSet as HashSet
 import qualified Data.Text as T
 
 
@@ -128,3 +134,81 @@ configToCliCommand ConfigP{..} = "stan " <> T.intercalate " \\\n     " (map chec
         CheckScopeFile file -> " --file=" <> toText file
         CheckScopeDirectory dir -> " --directory=" <> toText dir
         CheckScopeModule m -> " --module=" <> unModuleName m
+
+{- | Convert the list of 'Check's from 'Config' to data structure that
+allows filtering of 'Inspection's.
+-}
+applyChecks :: [FilePath] -> [Check] -> HashMap FilePath (HashSet (Id Inspection))
+applyChecks paths = foldl' useCheck filesMap
+  where
+    filesMap :: HashMap FilePath (HashSet (Id Inspection))
+    filesMap = HashMap.fromList $ map (, inspectionsIds) paths
+
+    useCheck
+        :: HashMap FilePath (HashSet (Id Inspection))
+        -> Check
+        -> HashMap FilePath (HashSet (Id Inspection))
+    useCheck dict Check{..} =
+        applyForScope (applyFilter checkType checkFilter) checkScope dict
+
+    applyFilter
+        :: CheckType
+        -> Maybe CheckFilter
+        -> HashSet (Id Inspection)
+        -> HashSet (Id Inspection)
+    applyFilter = \case
+        Include -> includeFilter
+        Ignore -> ignoreFilter
+
+    ignoreFilter :: Maybe CheckFilter -> HashSet (Id Inspection) -> HashSet (Id Inspection)
+    ignoreFilter cFilter = HashSet.filter (not . satisfiesFilter cFilter)
+
+    includeFilter :: Maybe CheckFilter -> HashSet (Id Inspection) -> HashSet (Id Inspection)
+    includeFilter mFilter ins = case mFilter of
+         -- add all inspections to the existing ones
+         Nothing -> inspectionsIds <> ins
+         Just cFilter -> case cFilter of
+             CheckInspection iId -> HashSet.insert iId ins
+             CheckObservation _ -> ins
+             CheckSeverity sev ->
+                 let sevInspections = filter ((== sev) . inspectionSeverity) inspections
+                 in HashSet.fromList (map inspectionId sevInspections) <> ins
+             CheckCategory cat ->
+                 let catInspections = filter (elem cat . inspectionCategory) inspections
+                 in HashSet.fromList (map inspectionId catInspections) <> ins
+
+    -- Returns 'True' if the given inspection satisfies 'CheckFilter'
+    satisfiesFilter :: Maybe CheckFilter -> Id Inspection -> Bool
+    satisfiesFilter mFilter iId = case mFilter of
+        Nothing -> True  -- no filter, always satisfies
+        -- TODO: rewrite more efficiently after using GHC-8.10
+        Just cFilter -> case lookupInspectionById iId of
+            Nothing -> False  -- no such ID => doesn't satisfy
+            Just Inspection{..} -> case cFilter of
+                CheckInspection checkId -> iId == checkId
+                CheckObservation _      -> False
+                CheckSeverity sev       -> sev == inspectionSeverity
+                CheckCategory cat       -> elem cat inspectionCategory
+
+    applyForScope
+        :: (HashSet (Id Inspection) -> HashSet (Id Inspection))
+        -> Maybe CheckScope
+        -> HashMap FilePath (HashSet (Id Inspection))
+        -> HashMap FilePath (HashSet (Id Inspection))
+    applyForScope f mScope hm = case mScope of
+        Nothing -> f <$> hm  -- no scope = apply for everything
+        Just cScope -> case cScope of
+            CheckScopeFile path -> HashMap.alter (fmap f) path hm
+            CheckScopeDirectory dir ->
+                HashMap.fromList
+                $ mapKeepMaybe
+                    (\(path, ins) -> guard (isInDir dir path) *> pure (path, f ins))
+                $ HashMap.toList hm
+            CheckScopeModule _moduleName -> hm  -- TODO: no info about modules here :(
+
+    isInDir :: FilePath -> FilePath -> Bool
+    isInDir dir path = dir `isPrefixOf` path
+
+-- Like 'mapMaybe' but keeps the original element if function returns Nothing
+mapKeepMaybe :: (a -> Maybe a) -> [a] -> [a]
+mapKeepMaybe f = mapMaybe (\a -> f a <|> Just a)

--- a/src/Stan/Inspection/All.hs
+++ b/src/Stan/Inspection/All.hs
@@ -37,9 +37,9 @@ inspectionsMap =
 inspections :: [Inspection]
 inspections = sortWith inspectionId $ HM.elems inspectionsMap
 
--- | List of all inspection 'Id's.
-inspectionsIds :: [Id Inspection]
-inspectionsIds = HM.keys inspectionsMap
+-- | Set of all inspection 'Id's.
+inspectionsIds :: HashSet (Id Inspection)
+inspectionsIds = HM.keysSet inspectionsMap
 
 -- | Look up 'Inspection' by the given inspection 'Id'.
 lookupInspectionById :: Id Inspection -> Maybe Inspection


### PR DESCRIPTION
Resolves #120

The logic might be complicated, but I've tried to write it cleanly. Any suggestions are appreciated :slightly_smiling_face: I've decided that usage of config should be implemented in a separate issue. And I will write tests once we resolve all open questions...

**Open questions:**

1. When I work only with `[FilePath]`, I don't have info about `ModuleName`, so I can't easily apply `CheckScopeModule`...
2. Our config allows ignoring `Id Observation`. But when working only with `Inspection`, we don't have `Observation`. So our filtering should actually has 2 phases:
    1. First, we get for files only those `Inspections` we want to run.
    2. Once we get resulting observations, we should filter by observations. In this case, `HashMap FilePath (HashSet (Id Inspection))` should be changed to `HashMap FilePath ((HashSet (Id Inspection), HashSet (Id Observation)))`. Does it make sense? 
3. Some functions (e.g. filter by directory, getting all inspections by category) traverse the full list of inspections each time since we don't have fast ways to get all inspections by category or severity at the moment. I think this is okay for now, but in the future, we probably may need to optimize this somehow...