### PR TITLE
[#158] Add `remove` field in the Config

### DIFF
--- a/test/Test/Stan/Cli.hs
+++ b/test/Test/Stan/Cli.hs
@@ -6,13 +6,13 @@ import Hedgehog (forAll, (===))
 import Options.Applicative (ParserResult (Success), execParserPure)
 import Test.Hspec (Spec, describe, it, shouldBe)
 import Test.Hspec.Hedgehog (hedgehog)
-import Trial (trialToMaybe, withTag)
+import Trial (fiasco, trialToMaybe, withTag)
 
 import Stan.Cli (StanArgs (..), StanCommand (..), stanCliParser, stanParserPrefs)
-import Stan.Config (Check (..), CheckFilter (..), CheckScope (..), CheckType (..), Config,
-                    ConfigP (..), PartialConfig, configToCliCommand, finaliseConfig)
+import Stan.Config (Check (..), CheckFilter (..), CheckType (..), Config, ConfigP (..),
+                    PartialConfig, Scope (..), configToCliCommand, finaliseConfig)
 import Stan.Core.Id (Id (..))
-import Test.Stan.Gen (Property, genCheck, genConfig)
+import Test.Stan.Gen (Property, genCheck, genConfig, genScope)
 
 
 cliSpec :: Spec
@@ -27,30 +27,35 @@ cliSpec = describe "CLI configuration tests" $ do
     configExample :: Config
     configExample = ConfigP
         { configChecks = checks
+        , configRemoved = []
         }
 
     partialConfigExample :: PartialConfig
     partialConfigExample = ConfigP
         { configChecks = withTag "CLI" $ pure checks
+        , configRemoved = withTag "CLI" $ fiasco "No CLI option specified for: remove"
         }
 
     checks :: [Check]
     checks =
-        [ Check Ignore Nothing (Just $ CheckScopeDirectory "test/")
+        [ Check Ignore Nothing (Just $ ScopeDirectory "test/")
         , Check Include Nothing Nothing
         , Check Ignore (Just $ CheckInspection $ Id "STAN-0002") Nothing
         , Check
             Ignore
             (Just $ CheckInspection $ Id "STAN-0001")
-            (Just $ CheckScopeFile "src/MyFile.hs")
+            (Just $ ScopeFile "src/MyFile.hs")
         ]
 
 cliConfigRoundtripProperty :: Property
 cliConfigRoundtripProperty = hedgehog $ do
     check <- forAll genCheck
+    scope <- forAll genScope
     -- we need to have a non-empty list as empty list is Fiasco for CLI.
     config <- forAll $ genConfig <&> \c -> c
-        { configChecks = check : configChecks c }
+        { configChecks  = check : configChecks c
+        , configRemoved = scope : configRemoved c
+        }
     case execParserPure stanParserPrefs stanCliParser (stanCommand config) of
         Success (Stan StanArgs{..}) ->
             trialToMaybe (finaliseConfig stanArgsConfig) === Just config

--- a/test/Test/Stan/Config.hs
+++ b/test/Test/Stan/Config.hs
@@ -4,7 +4,7 @@ module Test.Stan.Config
 
 import Test.Hspec (Spec, describe, it, shouldBe)
 
-import Stan.Config (Check (..), CheckFilter (..), CheckScope (..), CheckType (..), applyChecks,
+import Stan.Config (Check (..), CheckFilter (..), CheckType (..), Scope (..), applyChecks,
                     mkDefaultChecks)
 import Stan.Core.Id (Id (..))
 import Stan.Inspection (Inspection)
@@ -36,13 +36,13 @@ applyChecksSpec = describe "applyCheck tests" $ do
     it "Ignoring single file works" $
         applyChecks
             files
-            [Check Ignore Nothing (Just $ CheckScopeFile "baz.hs")]
+            [Check Ignore Nothing (Just $ ScopeFile "baz.hs")]
           `shouldBe`
             HM.adjust (const mempty) "baz.hs" defMap
     it "Ignoring a directory works" $
         applyChecks
             files
-            [Check Ignore Nothing (Just $ CheckScopeDirectory "src/")]
+            [Check Ignore Nothing (Just $ ScopeDirectory "src/")]
           `shouldBe`
             ( HM.adjust (const mempty) "src/foo.hs"
             $ HM.adjust (const mempty) "src/bar.hs" defMap)
@@ -53,7 +53,7 @@ applyChecksSpec = describe "applyCheck tests" $ do
             [Check
                 Ignore
                 (Just $ CheckInspection iId)
-                (Just $ CheckScopeFile "baz.hs")
+                (Just $ ScopeFile "baz.hs")
             ]
           `shouldBe`
             HM.adjust (HS.delete iId) "baz.hs" defMap

--- a/test/Test/Stan/Gen.hs
+++ b/test/Test/Stan/Gen.hs
@@ -10,7 +10,7 @@ module Test.Stan.Gen
     , genCheck
     , genCheckType
     , genCheckFilter
-    , genCheckScope
+    , genScope
     , genSeverity
     , genCategory
     , genModuleName
@@ -19,8 +19,7 @@ module Test.Stan.Gen
 import Hedgehog (Gen, PropertyT)
 
 import Stan.Category (Category, stanCategories)
-import Stan.Config (Check (..), CheckFilter (..), CheckScope (..), CheckType (..), Config,
-                    ConfigP (..))
+import Stan.Config (Check (..), CheckFilter (..), CheckType (..), Config, ConfigP (..), Scope (..))
 import Stan.Core.Id (Id (..))
 import Stan.Core.ModuleName (ModuleName (..))
 import Stan.Severity (Severity)
@@ -47,13 +46,15 @@ genSmallString :: Gen String
 genSmallString = Gen.string (Range.linear 0 10) Gen.alphaNum
 
 genConfig :: Gen Config
-genConfig = ConfigP <$> genSmallList genCheck
+genConfig = ConfigP
+    <$> genSmallList genCheck
+    <*> genSmallList genScope
 
 genCheck :: Gen Check
 genCheck = Check
     <$> genCheckType
     <*> Gen.maybe genCheckFilter
-    <*> Gen.maybe genCheckScope
+    <*> Gen.maybe genScope
 
 genCheckFilter :: Gen CheckFilter
 genCheckFilter = Gen.choice
@@ -63,10 +64,10 @@ genCheckFilter = Gen.choice
     , CheckCategory    <$> genCategory
     ]
 
-genCheckScope :: Gen CheckScope
-genCheckScope = Gen.choice
-    [ CheckScopeFile      <$> genSmallString
-    , CheckScopeDirectory <$> genSmallString
+genScope :: Gen Scope
+genScope = Gen.choice
+    [ ScopeFile      <$> genSmallString
+    , ScopeDirectory <$> genSmallString
     ]
 
 genCheckType :: Gen CheckType

--- a/test/Test/Stan/Toml.hs
+++ b/test/Test/Stan/Toml.hs
@@ -5,10 +5,10 @@ module Test.Stan.Toml
 import Hedgehog (forAll, (===))
 import Test.Hspec (Spec, describe, it, shouldReturn)
 import Test.Hspec.Hedgehog (hedgehog)
-import Trial (Trial (..), withTag)
+import Trial (Trial (..), fiasco, withTag)
 
-import Stan.Config (Check (..), CheckFilter (..), CheckScope (..), CheckType (..), Config,
-                    ConfigP (..), PartialConfig, finaliseConfig)
+import Stan.Config (Check (..), CheckFilter (..), CheckType (..), Config, ConfigP (..),
+                    PartialConfig, Scope (..), finaliseConfig)
 import Stan.Core.Id (Id (..))
 import Stan.Toml (configCodec)
 import Test.Stan.Gen (Property, genConfig)
@@ -25,14 +25,15 @@ tomlSpec = describe "TOML configuration tests" $ do
     configExample :: PartialConfig
     configExample = ConfigP
         { configChecks = withTag "TOML" $ pure
-            [ Check Ignore Nothing (Just $ CheckScopeDirectory "test/")
+            [ Check Ignore Nothing (Just $ ScopeDirectory "test/")
             , Check Include Nothing Nothing
             , Check Ignore (Just $ CheckInspection $ Id "STAN-0002") Nothing
             , Check
                 Ignore
                 (Just $ CheckInspection $ Id "STAN-0001")
-                (Just $ CheckScopeFile "src/MyFile.hs")
+                (Just $ ScopeFile "src/MyFile.hs")
             ]
+        , configRemoved = withTag "TOML" $ pure [] <> fiasco "No TOML value is specified for key: remove"
         }
 
 configTomlRoundtripProperty :: Property
@@ -47,4 +48,5 @@ configTomlRoundtripProperty = hedgehog $ do
 toPartialConfig :: Config -> PartialConfig
 toPartialConfig ConfigP{..} = ConfigP
     { configChecks = withTag "TOML" $ pure configChecks
+    , configRemoved = withTag "TOML" $ pure configRemoved
     }


### PR DESCRIPTION
Resolves #158

I have renamed `CheckScope` -> `Scope`.

I will add `remove` tests later. For now at least property tests still pass, so it should be ok :)