### PR TITLE
[#100] Inspection: missing `infix` for operator

### DIFF
--- a/src/Stan/Analysis/Analyser.hs
+++ b/src/Stan/Analysis/Analyser.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BangPatterns #-}
+
 {- |
 Copyright: (c) 2020 Kowainik
 SPDX-License-Identifier: MPL-2.0
@@ -13,6 +15,8 @@ module Stan.Analysis.Analyser
 
 import HieTypes (HieAST (..), HieASTs (..), HieFile (..), Identifier, IdentifierDetails (..),
                  NodeInfo (..), TypeIndex)
+import Name (nameOccName)
+import OccName (isSymOcc, occNameString)
 import Slist (Slist, slist)
 import SrcLoc (RealSrcSpan)
 
@@ -22,7 +26,7 @@ import Stan.Hie.MatchType (hieMatchPatternType)
 import Stan.Inspection (Inspection (..), InspectionAnalysis (..))
 import Stan.NameMeta (NameMeta, hieMatchNameMeta)
 import Stan.Observation (Observations, mkObservation)
-import Stan.Pattern.Ast (PatternAst)
+import Stan.Pattern.Ast (PatternAst, fixity, typeSig)
 import Stan.Pattern.Type (PatternType)
 
 import qualified Data.Map.Strict as Map
@@ -36,6 +40,7 @@ analysisByInspection :: Inspection -> HieFile -> Observations
 analysisByInspection Inspection{..} = case inspectionAnalysis of
     FindName nameMeta patType -> analyseNameMeta inspectionId nameMeta patType
     FindAst patAst            -> analyseAst inspectionId patAst
+    Infix                     -> analyseInfix inspectionId
 
 {- | Check for occurrences of the specified function given via 'NameMeta'.
 -}
@@ -86,16 +91,114 @@ analyseAst
   -> PatternAst
   -> HieFile
   -> Observations
-analyseAst insId patAst hie@HieFile{..} =
-    mkObservation insId hie <$> findSpans hie_asts
+analyseAst insId patAst hie =
+    mkObservation insId hie <$> analyseAstWith matchPattern hie
   where
-    findSpans :: HieASTs TypeIndex -> Slist RealSrcSpan
-    findSpans =
-        S.concatMap findInAst
+    matchPattern :: HieAST TypeIndex -> Slist RealSrcSpan
+    matchPattern node@Node{..} =
+        memptyIfFalse (hieMatchPatternAst hie node patAst) (S.one nodeSpan)
+
+{- | Analyse HIE AST to find all operators which lack explicit fixity
+declaration.
+
+The algorithm is the following:
+
+1. Traverse AST and discover all top-level operators and @infix@
+declarations in a single pass.
+2. Compare two resulting sets to find out operators without @infix@
+declaration.
+-}
+analyseInfix
+    :: Id Inspection
+    -> HieFile
+    -> Observations
+analyseInfix insId hie =
+    let opDecls = analyseAstWith (matchInfix <> matchOperator) hie
+        (fixities, topOperators) = partitionDecls opDecls
+        operatorsWithoutFixity = Map.difference topOperators fixities
+    in mkObservation insId hie <$> slist (toList operatorsWithoutFixity)
+  where
+    -- returns list of operator names defined in a single fixity declaration:
+    -- infix 5 ***, +++, ???
+    matchInfix :: HieAST TypeIndex -> Slist OperatorDecl
+    matchInfix node@Node{..} = memptyIfFalse
+        (hieMatchPatternAst hie node fixity)
+        (S.concatMap nodeIds nodeChildren)
+
+    -- singleton or empty list with the top-level operator definition
+    matchOperator :: HieAST TypeIndex -> Slist OperatorDecl
+    matchOperator node@Node{..} = memptyIfFalse
+        (hieMatchPatternAst hie node typeSig)
+        (maybeToMonoid $ viaNonEmpty (extractOperatorName . head) nodeChildren)
+        -- first child of a parent is a name of a function/operator
+
+    -- return AST node identifier names as a sized list of texts
+    nodeIds :: HieAST TypeIndex -> Slist OperatorDecl
+    nodeIds =
+        S.concatMap identifierName
+        . Map.keys
+        . nodeIdentifiers
+        . nodeInfo
+
+    identifierName :: Identifier -> Slist OperatorDecl
+    identifierName = \case
+        Left _ -> mempty
+        Right name -> S.one $ Fixity $ toText $ occNameString $ nameOccName name
+
+    extractOperatorName :: HieAST TypeIndex -> Slist OperatorDecl
+    extractOperatorName Node{..} =
+        S.concatMap (topLevelOperatorName nodeSpan)
+        $ Map.keys
+        $ nodeIdentifiers nodeInfo
+
+    topLevelOperatorName :: RealSrcSpan -> Identifier -> Slist OperatorDecl
+    topLevelOperatorName srcSpan = \case
+        Left _ -> mempty
+        Right name ->
+            let occName = nameOccName name
+            in memptyIfFalse
+                (isSymOcc occName)  -- check if operator
+                (S.one $ Operator (toText $ occNameString occName) srcSpan)
+
+-- | Either top-level operator or fixity declaration
+data OperatorDecl
+    = Fixity Text
+    -- | Operator name with its position to display later
+    | Operator Text RealSrcSpan
+
+{- | Partition a foldable of operator declarations into two maps:
+
+1. Fixity declarations (mapped to @()@).
+2. Top-level operator names (mapped to their source positions.
+
+'Map' is used to be able to use the nice @merge@ function.
+-}
+partitionDecls :: Foldable f => f OperatorDecl -> (Map Text (), Map Text RealSrcSpan)
+partitionDecls = foldl' insertDecl mempty
+  where
+    insertDecl
+        :: (Map Text (), Map Text RealSrcSpan)
+        -> OperatorDecl
+        -> (Map Text (), Map Text RealSrcSpan)
+    insertDecl (!fixities, !topOperators) = \case
+        Fixity name -> (Map.insert name () fixities, topOperators)
+        Operator name srcSpan -> (fixities, Map.insert name srcSpan topOperators)
+
+analyseAstWith
+  :: forall a
+  .  (HieAST TypeIndex -> Slist a)
+  -- ^ Function to match AST node to some arbitrary type and return a
+  -- sized list of matched elements
+  -> HieFile
+  -> Slist a
+analyseAstWith match = findNodes . hie_asts
+  where
+    findNodes :: HieASTs TypeIndex -> Slist a
+    findNodes =
+        S.concatMap matchAst
         . Map.elems
         . getAsts
 
-    findInAst :: HieAST TypeIndex -> Slist RealSrcSpan
-    findInAst node@Node{..} =
-        slist [nodeSpan | hieMatchPatternAst hie node patAst]
-        <> S.concatMap findInAst nodeChildren
+    matchAst :: HieAST TypeIndex -> Slist a
+    matchAst node@Node{..} =
+        match node <> S.concatMap matchAst nodeChildren

--- a/src/Stan/Category.hs
+++ b/src/Stan/Category.hs
@@ -20,6 +20,7 @@ module Stan.Category
     , list
     , partial
     , spaceLeak
+    , syntax
     ) where
 
 import Colourista (formatWith, magentaBg)
@@ -54,6 +55,11 @@ antiPattern = Category "AntiPattern"
 spaceLeak :: Category
 spaceLeak = Category "SpaceLeak"
 
+{- | @Syntax@ category of Stan inspections. Usually used in
+'Stan.Severity.Style' inspections.
+-}
+syntax :: Category
+syntax = Category "Syntax"
 
 -- | The list of all available Stan 'Category's.
 stanCategories :: [Category]
@@ -63,4 +69,5 @@ stanCategories =
     , list
     , partial
     , spaceLeak
+    , syntax
     ]

--- a/src/Stan/Hie/MatchAst.hs
+++ b/src/Stan/Hie/MatchAst.hs
@@ -57,7 +57,9 @@ hieMatchPatternAst hie@HieFile{..} node@Node{..} = \case
         any (matchNameAndType nameMeta patType)
         $ Map.assocs
         $ nodeIdentifiers nodeInfo
-    PatternAstNode tags patChildren ->
+    PatternAstNode tags ->
+        tags `Set.isSubsetOf` nodeAnnotations nodeInfo
+    PatternAstNodeExact tags patChildren ->
            tags `Set.isSubsetOf` nodeAnnotations nodeInfo
         && checkWith (hieMatchPatternAst hie) nodeChildren patChildren
   where

--- a/src/Stan/Hie/MatchAst.hs
+++ b/src/Stan/Hie/MatchAst.hs
@@ -16,6 +16,7 @@ module Stan.Hie.MatchAst
     ( hieMatchPatternAst
     ) where
 
+import FastString (FastString)
 import HieTypes (HieAST (..), HieFile (..), Identifier, IdentifierDetails, NodeInfo (..), TypeIndex)
 import SrcLoc (RealSrcSpan, srcSpanEndCol, srcSpanStartCol, srcSpanStartLine)
 
@@ -58,9 +59,9 @@ hieMatchPatternAst hie@HieFile{..} node@Node{..} = \case
         $ Map.assocs
         $ nodeIdentifiers nodeInfo
     PatternAstNode tags ->
-        tags `Set.isSubsetOf` nodeAnnotations nodeInfo
+        matchAnnotations tags nodeInfo
     PatternAstNodeExact tags patChildren ->
-           tags `Set.isSubsetOf` nodeAnnotations nodeInfo
+           matchAnnotations tags nodeInfo
         && checkWith (hieMatchPatternAst hie) nodeChildren patChildren
   where
     -- take sub-bytestring from src according to a given span
@@ -71,6 +72,9 @@ hieMatchPatternAst hie@HieFile{..} node@Node{..} = \case
         $ BS.drop (srcSpanStartCol span - 1)
         $ Unsafe.at (srcSpanStartLine span - 1)
         $ BS8.lines hie_hs_src
+
+    matchAnnotations :: Set (FastString, FastString) -> NodeInfo TypeIndex -> Bool
+    matchAnnotations tags NodeInfo{..} = tags `Set.isSubsetOf` nodeAnnotations
 
     matchNameAndType
         :: NameMeta

--- a/src/Stan/Inspection.hs
+++ b/src/Stan/Inspection.hs
@@ -91,6 +91,8 @@ data InspectionAnalysis
     = FindName NameMeta PatternType
     -- | Find the specific part of the Haskell AST.
     | FindAst PatternAst
+    -- | Find all operators without matching @infix[r|l]@
+    | Infix
     deriving stock (Show, Eq)
 
 -- | Show 'Inspection' in a human-friendly format.

--- a/src/Stan/Inspection/All.hs
+++ b/src/Stan/Inspection/All.hs
@@ -21,6 +21,7 @@ import Stan.Inspection (Inspection (..), InspectionsMap)
 import Stan.Inspection.AntiPattern (antiPatternInspectionsMap)
 import Stan.Inspection.Infinite (infiniteInspectionsMap)
 import Stan.Inspection.Partial (partialInspectionsMap)
+import Stan.Inspection.Style (styleInspectionsMap)
 
 import qualified Data.HashMap.Strict as HM
 
@@ -31,6 +32,7 @@ inspectionsMap =
     partialInspectionsMap
     <> infiniteInspectionsMap
     <> antiPatternInspectionsMap
+    <> styleInspectionsMap
 
 {- | List of all inspections.
 -}

--- a/src/Stan/Inspection/Style.hs
+++ b/src/Stan/Inspection/Style.hs
@@ -1,0 +1,49 @@
+{- |
+Copyright: (c) 2020 Kowainik
+SPDX-License-Identifier: MPL-2.0
+Maintainer: Kowainik <xrom.xkov@gmail.com>
+
+Contains all 'Inspection's for style improvements.
+
+The __style__ inspections are in ranges:
+
+* @STAN-0301 .. STAN-0400@
+-}
+
+module Stan.Inspection.Style
+    ( -- * Style inspections
+      -- *** Missing fixity
+      stan0301
+
+      -- * All inspections
+    , styleInspectionsMap
+    ) where
+
+import Relude.Extra.Tuple (fmapToFst)
+
+import Stan.Core.Id (Id (..))
+import Stan.Inspection (Inspection (..), InspectionAnalysis (..), InspectionsMap)
+import Stan.Severity (Severity (Style))
+
+import qualified Stan.Category as Category
+
+
+-- | All anti-pattern 'Inspection's map from 'Id's.
+styleInspectionsMap :: InspectionsMap
+styleInspectionsMap = fromList $ fmapToFst inspectionId
+    [ stan0301
+    ]
+
+-- | 'Inspection' — missing fixity declaration @STAN-0301@.
+stan0301 :: Inspection
+stan0301 = Inspection
+    { inspectionId = Id "STAN-0301"
+    , inspectionName = "Missing fixity declaration for operator"
+    , inspectionDescription = "Using the implicit default fixity for operator: infixl 9"
+    , inspectionSolution =
+        [ "Add 'infix[l|r]' declaration to the operator with explicit precedence"
+        ]
+    , inspectionCategory = Category.syntax :| []
+    , inspectionSeverity = Style
+    , inspectionAnalysis = Infix
+    }

--- a/stan.cabal
+++ b/stan.cabal
@@ -98,6 +98,7 @@ library
                            Stan.Inspection.AntiPattern
                            Stan.Inspection.Infinite
                            Stan.Inspection.Partial
+                           Stan.Inspection.Style
                          Stan.NameMeta
                          Stan.Observation
                            Stan.Pattern.Ast
@@ -150,6 +151,7 @@ library target
   exposed-modules:     Target.AntiPattern
                        Target.Infinite
                        Target.Partial
+                       Target.Style
 
 test-suite stan-test
   import:              common-options
@@ -162,6 +164,7 @@ test-suite stan-test
                          Test.Stan.Analysis.Common
                          Test.Stan.Analysis.Infinite
                          Test.Stan.Analysis.Partial
+                         Test.Stan.Analysis.Style
                        Test.Stan.Cli
                        Test.Stan.Config
                        Test.Stan.Gen

--- a/target/Target/Style.hs
+++ b/target/Target/Style.hs
@@ -1,0 +1,7 @@
+{-# OPTIONS_GHC -fno-warn-missing-export-lists #-}
+
+module Target.Style where
+
+
+(???) :: Int -> Int -> Int
+(???) = (+)

--- a/target/Target/Style.hs
+++ b/target/Target/Style.hs
@@ -5,3 +5,7 @@ module Target.Style where
 
 (???) :: Int -> Int -> Int
 (???) = (+)
+
+infixl 7 ***
+(***) :: Int -> Int -> Int
+(***) = (*)

--- a/test/Test/Stan/Analysis.hs
+++ b/test/Test/Stan/Analysis.hs
@@ -11,6 +11,7 @@ import Stan.Config (mkDefaultChecks)
 import Test.Stan.Analysis.AntiPattern (analysisAntiPatternSpec)
 import Test.Stan.Analysis.Infinite (analysisInfiniteSpec)
 import Test.Stan.Analysis.Partial (analysisPartialSpec)
+import Test.Stan.Analysis.Style (analysisStyleSpec)
 
 import qualified Data.Set as Set
 
@@ -23,6 +24,7 @@ analysisSpec hieFiles = describe "Static Analysis" $ do
     analysisPartialSpec analysis
     analysisInfiniteSpec analysis
     analysisAntiPatternSpec analysis
+    analysisStyleSpec analysis
     analysisExtensionsSpec analysis
 
 

--- a/test/Test/Stan/Analysis/Style.hs
+++ b/test/Test/Stan/Analysis/Style.hs
@@ -1,0 +1,21 @@
+module Test.Stan.Analysis.Style
+    ( analysisStyleSpec
+    ) where
+
+import Test.Hspec (Spec, describe, it)
+
+import Stan.Analysis (Analysis)
+import Test.Stan.Analysis.Common (observationAssert)
+
+import qualified Stan.Inspection.Style as Style
+
+
+analysisStyleSpec :: Analysis -> Spec
+analysisStyleSpec analysis = describe "Style" $ do
+    let checkObservation = observationAssert
+            "Target/Style.hs"
+            "Target.Style"
+            analysis
+
+    it "STAN-0301: finds operator with the missing infix" $
+        checkObservation Style.stan0301 6 1 6

--- a/test/Test/Stan/Analysis/Style.hs
+++ b/test/Test/Stan/Analysis/Style.hs
@@ -5,7 +5,7 @@ module Test.Stan.Analysis.Style
 import Test.Hspec (Spec, describe, it)
 
 import Stan.Analysis (Analysis)
-import Test.Stan.Analysis.Common (observationAssert)
+import Test.Stan.Analysis.Common (noObservationAssert, observationAssert)
 
 import qualified Stan.Inspection.Style as Style
 
@@ -16,6 +16,12 @@ analysisStyleSpec analysis = describe "Style" $ do
             "Target/Style.hs"
             "Target.Style"
             analysis
+    let noObservation = noObservationAssert
+            "Target/Style.hs"
+            "Target.Style"
+            analysis
 
     it "STAN-0301: finds operator with the missing infix" $
         checkObservation Style.stan0301 6 1 6
+    it "STAN-0301: no warning when fixity is declared" $
+        noObservation Style.stan0301 10

--- a/test/Test/Stan/Number.hs
+++ b/test/Test/Stan/Number.hs
@@ -18,4 +18,3 @@ modulesNumSpec :: Int -> Spec
 modulesNumSpec num = describe "Modules number tests" $
     it "should count correct number of modules" $
         num `shouldBe` 55
-        num `shouldBe` 54

--- a/test/Test/Stan/Number.hs
+++ b/test/Test/Stan/Number.hs
@@ -17,4 +17,5 @@ linesOfCodeSpec hieFile = describe "LoC tests" $
 modulesNumSpec :: Int -> Spec
 modulesNumSpec num = describe "Modules number tests" $
     it "should count correct number of modules" $
-        num `shouldBe` 52
+        num `shouldBe` 55
+        num `shouldBe` 54


### PR DESCRIPTION
Resolves #100

A new inspection looks like this:

![Screenshot from 2020-06-04 22-53-52](https://user-images.githubusercontent.com/4276606/83813955-547da300-a6b6-11ea-8d01-70d5db736982.png)

The heaviest module is `Stan.Analysis.Analyser`. It contains the main logic for processing the AST and collecting all operators.

What else is done:

* New `Stan.Inspection.Style` module for the `Style :: Severity` inspections
* New constructor to `PatternAst` to match on any number of children nodes
* New AST patterns to handle fixities

Open questions and what else needs to be done:

1. More tests when the inspection doesn't trigger?
2. Currently, doesn't handle operators as a part of typeclasses (no warning on `(?)` from `PatternBool` eDSL).
3. Also warns on operators inside `where`.
