### PR TITLE
[#171] Inspection: strict data type fields

### DIFF
--- a/src/Stan/Analysis.hs
+++ b/src/Stan/Analysis.hs
@@ -167,7 +167,9 @@ analyseHieFile hieFile@HieFile{..} cabalExts obs insIds = do
     let fileInfoMergedExtensions = mergeParsedExtensions fileInfoCabalExtensions fileInfoExtensions
     -- get list of inspections for the file
     let ins = mapMaybe lookupInspectionById (toList insIds)
-    let allObservations = S.concatMap (`analysisByInspection` hieFile) ins
+    let allObservations = S.concatMap
+            (\iId -> analysisByInspection fileInfoMergedExtensions iId hieFile)
+            ins
     let (ignoredObs, fileInfoObservations) = S.partition ((`elem` obs) . observationId) allObservations
 
     incModulesNum

--- a/src/Stan/Analysis/Analyser.hs
+++ b/src/Stan/Analysis/Analyser.hs
@@ -225,9 +225,9 @@ analyseInfix insId hie =
 
 -- | Either top-level operator or fixity declaration
 data OperatorDecl
-    = Fixity Text
+    = Fixity !Text
     -- | Operator name with its position to display later
-    | Operator Text RealSrcSpan
+    | Operator !Text !RealSrcSpan
 
 {- | Partition a foldable of operator declarations into two maps:
 

--- a/src/Stan/Analysis/Analyser.hs
+++ b/src/Stan/Analysis/Analyser.hs
@@ -13,6 +13,8 @@ module Stan.Analysis.Analyser
     ( analysisByInspection
     ) where
 
+import Extensions (ExtensionsResult)
+import GHC.LanguageExtensions.Type (Extension (Strict, StrictData))
 import HieTypes (HieAST (..), HieASTs (..), HieFile (..), Identifier, IdentifierDetails (..),
                  NodeInfo (..), TypeIndex)
 import Name (nameOccName)
@@ -21,27 +23,36 @@ import Slist (Slist, slist)
 import SrcLoc (RealSrcSpan)
 
 import Stan.Core.Id (Id)
+import Stan.FileInfo (isExtensionDisabled)
 import Stan.Hie.MatchAst (hieMatchPatternAst)
 import Stan.Hie.MatchType (hieMatchPatternType)
 import Stan.Inspection (Inspection (..), InspectionAnalysis (..))
 import Stan.NameMeta (NameMeta, hieMatchNameMeta)
 import Stan.Observation (Observations, mkObservation)
-import Stan.Pattern.Ast (PatternAst, fixity, typeSig)
+import Stan.Pattern.Ast (PatternAst, constructor, dataDecl, fixity, lazyField, typeSig)
 import Stan.Pattern.Type (PatternType)
 
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 import qualified Slist as S
 
 
 {- | Create analysing function for 'Inspection' by pattern-matching
 over 'InspectionAnalysis'.
 -}
-analysisByInspection :: Inspection -> HieFile -> Observations
-analysisByInspection Inspection{..} = case inspectionAnalysis of
+analysisByInspection
+    :: ExtensionsResult
+    -> Inspection
+    -> HieFile
+    -> Observations
+analysisByInspection exts Inspection{..} = case inspectionAnalysis of
     FindName nameMeta patType -> analyseNameMeta inspectionId nameMeta patType
     FindAst patAst            -> analyseAst inspectionId patAst
     Infix                     -> analyseInfix inspectionId
+    LazyField                 -> memptyIfFalse
+        (isExtensionDisabled StrictData exts && isExtensionDisabled Strict exts)
+        (analyseLazyFields inspectionId)
 
 {- | Check for occurrences of the specified function given via 'NameMeta'.
 -}
@@ -93,11 +104,62 @@ analyseAst
   -> HieFile
   -> Observations
 analyseAst insId patAst hie =
-    mkObservation insId hie <$> analyseAstWith matchPattern hie
+    mkObservation insId hie <$> analyseAstWith (createMatch patAst hie) hie
+
+{- | Check for occurrences lazy fields in all constructors. Ignores
+@newtype@s. Currently HIE Ast doesn't have information whether the
+data type is @newtype@ or not. So the algorithm ignores all data types
+with a single constructor and single field inside that constructor.
+-}
+analyseLazyFields
+  :: Id Inspection
+  -> HieFile
+  -> Observations
+analyseLazyFields insId hie =
+    mkObservation insId hie <$> analyseAstWith matchLazyField hie
   where
-    matchPattern :: HieAST TypeIndex -> Slist RealSrcSpan
-    matchPattern node@Node{..} =
-        memptyIfFalse (hieMatchPatternAst hie node patAst) (S.one nodeSpan)
+    matchLazyField :: HieAST TypeIndex -> Slist RealSrcSpan
+    matchLazyField node = memptyIfFalse
+        -- return empty list if it's not a data type
+        (hieMatchPatternAst hie node dataDecl)
+        -- get list of all constructors
+        $ let constructors = filter
+                (\n -> hieMatchPatternAst hie n constructor)
+                (nodeChildren node)
+          in case constructors of
+              -- no constructors = not observations
+              []  -> mempty
+              -- single constructor
+              [c] -> S.concatMap matchField $ extractFields False c
+              -- multiple constructors = analyse everything
+              cs  -> S.concatMap (S.concatMap matchField . extractFields True) cs
+
+    -- Extract fields as AST nodes. Return empty list if only one field
+    -- (as a workaround for the @newtype@ problem)
+    --
+    -- record constructors have 2 children:
+    --   1. Constructor name.
+    --   2. Dummy child with all fields as childrens
+    -- plain constructors have constructor name and children in the same list
+    extractFields :: Bool -> HieAST TypeIndex -> [HieAST TypeIndex]
+    extractFields hasManyCtors ctor = case drop 1 $ nodeChildren ctor of
+        [] -> []  -- no fields
+        [n] ->  -- single field, maybe dummy record node
+            if isDummyRecordNode n
+            then case nodeChildren n of
+                []      -> []
+                [field] -> [field | hasManyCtors]
+                fields  -> fields
+            else [n | hasManyCtors]
+        fields -> fields  -- plain constructor
+      where
+        -- simple check for the dummy AST node
+        isDummyRecordNode :: HieAST TypeIndex -> Bool
+        isDummyRecordNode = Set.null . nodeAnnotations . nodeInfo
+
+    -- matches record fields non-recursively
+    matchField :: HieAST TypeIndex -> Slist RealSrcSpan
+    matchField = createMatch lazyField hie
 
 {- | Analyse HIE AST to find all operators which lack explicit fixity
 declaration.
@@ -188,6 +250,8 @@ partitionDecls = foldl' insertDecl mempty
         Fixity name -> (HM.insert name () fixities, topOperators)
         Operator name srcSpan -> (fixities, HM.insert name srcSpan topOperators)
 
+{- | Analyses the whole AST starting from the very top.
+-}
 analyseAstWith
   :: forall a
   .  (HieAST TypeIndex -> Slist a)
@@ -199,10 +263,32 @@ analyseAstWith match = findNodes . hie_asts
   where
     findNodes :: HieASTs TypeIndex -> Slist a
     findNodes =
-        S.concatMap matchAst
+        S.concatMap (matchAstWith match)
         . Map.elems
         . getAsts
 
+{- | Recursively match AST nodes starting from a given AST.
+-}
+matchAstWith
+  :: forall a
+  .  (HieAST TypeIndex -> Slist a)
+  -- ^ Function to match AST node to some arbitrary type and return a
+  -- sized list of matched elements
+  -> HieAST TypeIndex
+  -> Slist a
+matchAstWith match = matchAst
+  where
     matchAst :: HieAST TypeIndex -> Slist a
     matchAst node@Node{..} =
         match node <> S.concatMap matchAst nodeChildren
+
+{- | Create a non-recursive matching function for 'PatternAst' that
+returns sized list of source positions for nodes that matches this
+pattern.
+
+* If the pattern matches 'Node', return it
+* Otherwise return empty list
+-}
+createMatch :: PatternAst -> HieFile -> (HieAST TypeIndex -> Slist RealSrcSpan)
+createMatch patAst hie node@Node{..} =
+    memptyIfFalse (hieMatchPatternAst hie node patAst) (S.one nodeSpan)

--- a/src/Stan/Cli.hs
+++ b/src/Stan/Cli.hs
@@ -43,10 +43,10 @@ import Stan.Report.Settings (ReportSettings (..))
 
 -- | Commands used in Stan CLI.
 data StanCommand
-    = Stan StanArgs  -- ^ Just @stan@ with its options.
-    | StanInspection InspectionArgs  -- ^ @stan inspection@.
-    | StanTomlToCli TomlToCliArgs  -- ^ @stan toml-to-cli@
-    | StanCliToToml CliToTomlArgs  -- ^ @stan cli-to-toml@
+    = Stan !StanArgs  -- ^ Just @stan@ with its options.
+    | StanInspection !InspectionArgs  -- ^ @stan inspection@.
+    | StanTomlToCli !TomlToCliArgs  -- ^ @stan toml-to-cli@
+    | StanCliToToml !CliToTomlArgs  -- ^ @stan cli-to-toml@
 
 -- | Options used for the main @stan@ command.
 data StanArgs = StanArgs
@@ -191,9 +191,9 @@ toggleSolutionP = flag ShowSolution HideSolution $ mconcat
     ]
 
 data ConfigCommand
-    = CheckCommand Check
-    | RemoveCommand Scope
-    | IgnoreCommand (Id Observation)
+    = CheckCommand !Check
+    | RemoveCommand !Scope
+    | IgnoreCommand !(Id Observation)
 
 partitionCommands :: [ConfigCommand] -> ([Check], [Scope], [Id Observation])
 partitionCommands [] = ([], [], [])

--- a/src/Stan/Config.hs
+++ b/src/Stan/Config.hs
@@ -106,16 +106,16 @@ data Check = Check
 
 -- | Criterion for inspections filtering.
 data CheckFilter
-    = CheckInspection (Id Inspection)
-    | CheckSeverity Severity
-    | CheckCategory Category
+    = CheckInspection !(Id Inspection)
+    | CheckSeverity !Severity
+    | CheckCategory !Category
     | CheckAll
     deriving stock (Show, Eq)
 
 -- | Where to apply the rule for controlling inspection set.
 data Scope
-    = ScopeFile FilePath
-    | ScopeDirectory FilePath
+    = ScopeFile !FilePath
+    | ScopeDirectory !FilePath
     | ScopeAll
     deriving stock (Show, Eq)
 

--- a/src/Stan/FileInfo.hs
+++ b/src/Stan/FileInfo.hs
@@ -53,5 +53,5 @@ isExtensionDisabled :: Extension -> ExtensionsResult -> Bool
 isExtensionDisabled ext = \case
     Left _ -> True  -- no info about extensions, consider it disabled
     Right Extensions{..} ->
-           Set.member (Off ext) extensionsAll
-        || Set.notMember (On ext) extensionsAll
+           Set.notMember (On ext) extensionsAll
+        || Set.member (Off ext) extensionsAll

--- a/src/Stan/FileInfo.hs
+++ b/src/Stan/FileInfo.hs
@@ -11,12 +11,17 @@ module Stan.FileInfo
     , FileInfo (..)
 
     , extensionsToText
+    , isExtensionDisabled
     ) where
 
-import Extensions (ExtensionsError, ExtensionsResult, ParsedExtensions (..), showOnOffExtension)
+import Extensions (Extensions (..), ExtensionsError, ExtensionsResult, OnOffExtension (..),
+                   ParsedExtensions (..), showOnOffExtension)
+import GHC.LanguageExtensions.Type (Extension)
 
 import Stan.Core.ModuleName (ModuleName)
 import Stan.Observation (Observations)
+
+import qualified Data.Set as Set
 
 
 -- | File specific information.
@@ -41,3 +46,12 @@ extensionsToText = \case
         case parsedExtensionsSafe of
             Just s  -> show s : exts
             Nothing -> exts
+
+{- | Check whether the given extension is disabled
+-}
+isExtensionDisabled :: Extension -> ExtensionsResult -> Bool
+isExtensionDisabled ext = \case
+    Left _ -> True  -- no info about extensions, consider it disabled
+    Right Extensions{..} ->
+           Set.member (Off ext) extensionsAll
+        || Set.notMember (On ext) extensionsAll

--- a/src/Stan/Inspection.hs
+++ b/src/Stan/Inspection.hs
@@ -88,9 +88,9 @@ inspections in a uniformed way.
 -}
 data InspectionAnalysis
     -- | Find specific function name by specified 'PatternType'.
-    = FindName NameMeta PatternType
+    = FindName !NameMeta !PatternType
     -- | Find the specific part of the Haskell AST.
-    | FindAst PatternAst
+    | FindAst !PatternAst
     -- | Find all operators without matching @infix[r|l]@
     | Infix
     -- | Check if the data type has lazy fields

--- a/src/Stan/Inspection.hs
+++ b/src/Stan/Inspection.hs
@@ -93,6 +93,8 @@ data InspectionAnalysis
     | FindAst PatternAst
     -- | Find all operators without matching @infix[r|l]@
     | Infix
+    -- | Check if the data type has lazy fields
+    | LazyField
     deriving stock (Show, Eq)
 
 -- | Show 'Inspection' in a human-friendly format.

--- a/src/Stan/Inspection/AntiPattern.hs
+++ b/src/Stan/Inspection/AntiPattern.hs
@@ -23,6 +23,8 @@ module Stan.Inspection.AntiPattern
     , stan0204
       -- *** Anti-pattern slow 'size' for 'HashSet'
     , stan0205
+      -- *** Anti-pattern: Lazy fields
+    , stan0206
 
       -- * All inspections
     , antiPatternInspectionsMap
@@ -51,6 +53,7 @@ antiPatternInspectionsMap = fromList $ fmapToFst inspectionId
     , stan0203
     , stan0204
     , stan0205
+    , stan0206
     ]
 
 -- | Smart constructor to create anti-pattern 'Inspection'.
@@ -147,3 +150,19 @@ stan0205 = mkAntiPatternInspection (Id "STAN-0205") "HashSet size"
         , nameMetaModuleName = "Data.HashSet.Base"
         , nameMetaName       = "size"
         }
+
+-- | 'Inspection' — missing fixity declaration @STAN-0206@.
+stan0206 :: Inspection
+stan0206 = Inspection
+    { inspectionId = Id "STAN-0206"
+    , inspectionName = "Data types with non-strict fields"
+    , inspectionDescription =
+        "Defining lazy fields in data types can lead to unexpected space leaks"
+    , inspectionSolution =
+        [ "Add '!' before the type, e.g. !Int or !(Maybe Bool)"
+        , "Enable the 'StrictData' extension: {-# LANGUAGE StrictData #-}"
+        ]
+    , inspectionCategory = Category.spaceLeak :| [Category.syntax]
+    , inspectionSeverity = Performance
+    , inspectionAnalysis = LazyField
+    }

--- a/src/Stan/Pattern/Ast.hs
+++ b/src/Stan/Pattern/Ast.hs
@@ -120,6 +120,7 @@ cases:
 * Type in parenthesis: (Int)
 * Tuples: (Int, Bool)
 * List type: [Int]
+* Function type: Int -> Bool
 -}
 type_ :: PatternAst
 type_ =
@@ -132,6 +133,8 @@ type_ =
     PatternAstNode (one ("HsTupleTy", "HsType"))  -- tuple types: (Int, Bool)
     |||
     PatternAstNode (one ("HsListTy", "HsType"))  -- list types: [Int]
+    |||
+    PatternAstNode (one ("HsFunTy", "HsType"))  -- function types: Int -> Bool
 
 {- | Pattern for the field without the explicit bang pattern:
 

--- a/src/Stan/Pattern/Ast.hs
+++ b/src/Stan/Pattern/Ast.hs
@@ -33,25 +33,25 @@ low-level, but helper functions are provided.
 -}
 data PatternAst
     -- | Integer constant in code.
-    = PatternAstConstant Int  -- TODO: support constants of different types
+    = PatternAstConstant !Int  -- TODO: support constants of different types
     -- | Name of a specific function, variable or data type.
-    | PatternAstName NameMeta PatternType
+    | PatternAstName !NameMeta !PatternType
     -- | AST node with tags for current node and any children.
     | PatternAstNode
-        (Set (FastString, FastString))  -- ^ Set of context info (pairs of tags)
+        !(Set (FastString, FastString))  -- ^ Set of context info (pairs of tags)
     -- | AST node with tags for current node and children
     -- patterns. This pattern should match the node exactly.
     | PatternAstNodeExact
-        (Set (FastString, FastString))  -- ^ Set of context info (pairs of tags)
-        [PatternAst]  -- ^ Node children
+        !(Set (FastString, FastString))  -- ^ Set of context info (pairs of tags)
+        ![PatternAst]  -- ^ Node children
     -- | AST wildcard, matches anything.
     | PatternAstAnything
     -- | Choice between patterns. Should match either of them.
-    | PatternAstOr PatternAst PatternAst
+    | PatternAstOr !PatternAst !PatternAst
     -- | Union of patterns. Should match both of them.
-    | PatternAstAnd PatternAst PatternAst
+    | PatternAstAnd !PatternAst !PatternAst
     -- | Negation of pattern. Should match everything except this pattern.
-    | PatternAstNeg PatternAst
+    | PatternAstNeg !PatternAst
     deriving stock (Show, Eq)
 
 instance PatternBool PatternAst where

--- a/src/Stan/Pattern/Ast.hs
+++ b/src/Stan/Pattern/Ast.hs
@@ -12,7 +12,10 @@ module Stan.Pattern.Ast
 
       -- * eDSL
     , app
+    , constructor
+    , dataDecl
     , fixity
+    , lazyField
     , range
     , typeSig
     ) where
@@ -81,7 +84,7 @@ infixr 7 ***, +++, ???
 fixity :: PatternAst
 fixity = PatternAstNode $ one ("FixitySig", "FixitySig")
 
-{- | Pattern for a type signature declaration:
+{- | Pattern for the function type signature declaration:
 
 @
 foo :: Some -> Type
@@ -89,3 +92,61 @@ foo :: Some -> Type
 -}
 typeSig :: PatternAst
 typeSig = PatternAstNode $ one ("TypeSig", "Sig")
+
+{- | @data@ or @newtype@ declaration.
+-}
+dataDecl :: PatternAst
+dataDecl = PatternAstNode $ one ("DataDecl", "TyClDecl")
+
+{- | Constructor of a plain data type or newtype. Children of node
+that matches this pattern are constructor fields.
+-}
+constructor :: PatternAst
+constructor = PatternAstNode $ one ("ConDeclH98", "ConDecl")
+
+{- | Lazy data type field. Comes in two shapes:
+
+1. Record field, like: @foo :: Text@
+2. Simple type: @Int@
+-}
+lazyField :: PatternAst
+lazyField = lazyRecordField ||| type_
+
+{- | Pattern for any occurrence of a plain type. Covers the following
+cases:
+
+* Simple type: Int, Bool, a
+* Higher-kinded type: Maybe Int, Either String a
+* Type in parenthesis: (Int)
+* Tuples: (Int, Bool)
+* List type: [Int]
+-}
+type_ :: PatternAst
+type_ =
+    PatternAstNode (one ("HsTyVar", "HsType"))  -- simple type: Int, Bool
+    |||
+    PatternAstNode (one ("HsAppTy", "HsType"))  -- composite: Maybe Int
+    |||
+    PatternAstNode (one ("HsParTy", "HsType"))  -- type in ()
+    |||
+    PatternAstNode (one ("HsTupleTy", "HsType"))  -- tuple types: (Int, Bool)
+    |||
+    PatternAstNode (one ("HsListTy", "HsType"))  -- list types: [Int]
+
+{- | Pattern for the field without the explicit bang pattern:
+
+@
+someField :: Int
+@
+-}
+lazyRecordField :: PatternAst
+lazyRecordField = PatternAstNodeExact
+    (one ("ConDeclField", "ConDeclField"))
+    [ PatternAstNode
+        (fromList
+            [ ("AbsBinds", "HsBindLR")
+            , ("FunBind", "HsBindLR")
+            ]
+        )
+    , type_
+    ]

--- a/src/Stan/Pattern/Type.hs
+++ b/src/Stan/Pattern/Type.hs
@@ -39,17 +39,17 @@ data PatternType
     | @Either Int String@ | @PatternName (NameMeta ... \"Either\") [intPattern, stringPattern]@ |
     +---------------------+---------------------------------------------------------------------+
     -}
-    = PatternTypeName NameMeta [PatternType]
+    = PatternTypeName !NameMeta ![PatternType]
     -- | Function pattern.
-    | PatternTypeFun PatternType PatternType
+    | PatternTypeFun !PatternType !PatternType
     -- | Type wildcard, matches anything.
     | PatternTypeAnything
     -- | Choice between patterns. Should match either of them.
-    | PatternTypeOr PatternType PatternType
+    | PatternTypeOr !PatternType !PatternType
     -- | Union of patterns. Should match both of them.
-    | PatternTypeAnd PatternType PatternType
+    | PatternTypeAnd !PatternType !PatternType
     -- | Negation of pattern. Should match everything except this pattern.
-    | PatternTypeNeg PatternType
+    | PatternTypeNeg !PatternType
     deriving stock (Show, Eq)
 
 instance PatternBool PatternType where

--- a/stan.cabal
+++ b/stan.cabal
@@ -129,6 +129,7 @@ library
                      , extensions ^>= 0.0.0.1
                      , filepath ^>= 1.4
                      , ghc ^>= 8.8
+                     , ghc-boot-th ^>= 8.8
                      , ghc-paths ^>= 0.1.0.12
                      , gitrev ^>= 1.3.1
                      , optparse-applicative ^>= 0.15
@@ -153,6 +154,8 @@ library target
   build-depends:       bytestring
                      , unordered-containers
   exposed-modules:     Target.AntiPattern
+                         Target.AntiPattern.Stan0206
+                         Target.AntiPattern.Stan0206Extensions
                        Target.Infinite
                        Target.Partial
                        Target.Style

--- a/target/Target/AntiPattern/Stan0206.hs
+++ b/target/Target/AntiPattern/Stan0206.hs
@@ -1,0 +1,22 @@
+{-# OPTIONS_GHC -fno-warn-missing-export-lists #-}
+
+module Target.AntiPattern.Stan0206 where
+
+
+data RecordExample a = RecordExample
+    { strictField :: !Int
+    , lazyField   :: Int
+    , lazyVar     :: a
+    }
+
+newtype NewtypeExample1 = NewtypeExample1 Bool
+newtype NewtypeExample2 = NewtypeExample2
+    { unWrap :: Int
+    }
+
+data PlainExample
+    = Mk1
+        !Int
+        Int
+    | Mk2 !Int
+    | Mk3 Bool

--- a/target/Target/AntiPattern/Stan0206Extensions.hs
+++ b/target/Target/AntiPattern/Stan0206Extensions.hs
@@ -1,0 +1,13 @@
+{-# OPTIONS_GHC -fno-warn-missing-export-lists #-}
+
+{-# LANGUAGE StrictData #-}
+
+module Target.AntiPattern.Stan0206Extensions where
+
+
+data Record a = Record
+    { field1 :: Int
+    , field2 :: ~a
+    }
+
+data User = User Int String

--- a/test/Test/Stan/Analysis.hs
+++ b/test/Test/Stan/Analysis.hs
@@ -31,6 +31,6 @@ analysisSpec hieFiles = describe "Static Analysis" $ do
 analysisExtensionsSpec :: Analysis -> Spec
 analysisExtensionsSpec Analysis{..} = describe "Used extensions" $ do
     it "should correctly count total amount of used extensions" $
-        Set.size (fst analysisUsedExtensions) `shouldBe` 14
+        Set.size (fst analysisUsedExtensions) `shouldBe` 15
     it "should correctly count total amount of used safe extensions" $
         Set.size (snd analysisUsedExtensions) `shouldBe` 0

--- a/test/Test/Stan/Analysis/AntiPattern.hs
+++ b/test/Test/Stan/Analysis/AntiPattern.hs
@@ -33,3 +33,49 @@ analysisAntiPatternSpec analysis = describe "Anti-patterns" $ do
         checkObservation AntiPattern.stan0204 23 19 26
     it "STAN-0205: finds usage of 'Data.HashSet.size'" $
         checkObservation AntiPattern.stan0205 26 19 26
+
+    strictFieldsSpec analysis
+
+strictFieldsSpec :: Analysis -> Spec
+strictFieldsSpec analysis = describe "STAN-0206: Strict data type fields" $ do
+    describe "Without extensions" $ do
+        let checkObservation = observationAssert
+                "Target/AntiPattern/Stan0206.hs"
+                "Target.AntiPattern.Stan0206"
+                analysis
+        let noObservation = noObservationAssert
+                "Target/AntiPattern/Stan0206.hs"
+                "Target.AntiPattern.Stan0206"
+                analysis
+
+        it "Doesn't trigger on strict field" $
+            noObservation AntiPattern.stan0206 7
+        it "Finds simple lazy field" $
+            checkObservation AntiPattern.stan0206 8 7 25
+        it "Finds polymorphic lazy field" $
+            checkObservation AntiPattern.stan0206 9 7 23
+        it "Doesn't trigger on plain newtype" $
+            noObservation AntiPattern.stan0206 12
+        it "Doesn't trigger on a record newtype" $
+            noObservation AntiPattern.stan0206 14
+        it "Doesn't trigger on strict sum type field among many fields" $
+            noObservation AntiPattern.stan0206 19
+        it "Finds lazy field in a sum type constructor with multiple fields" $
+            checkObservation AntiPattern.stan0206 20 9 12
+        it "Doesn't trigger on a single strict sum type field" $
+            noObservation AntiPattern.stan0206 21
+        it "Finds single lazy field in a sum type with multiple constructors" $
+            checkObservation AntiPattern.stan0206 22 11 15
+
+    describe "With the 'StrictData' extension" $ do
+        let noObservation = noObservationAssert
+                "Target/AntiPattern/Stan0206Extensions.hs"
+                "Target.AntiPattern.Stan0206Extensions"
+                analysis
+
+        it "Doesn't trigger on a simple record field" $
+            noObservation AntiPattern.stan0206 9
+        it "Doesn't trigger on explicitly lazy field" $
+            noObservation AntiPattern.stan0206 10
+        it "Doesn't trigger on plain data type" $
+            noObservation AntiPattern.stan0206 13

--- a/test/Test/Stan/Number.hs
+++ b/test/Test/Stan/Number.hs
@@ -4,7 +4,7 @@ module Test.Stan.Number
     ) where
 
 import HieTypes (HieFile (..))
-import Test.Hspec (Spec, describe, it, shouldBe)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
 
 import Stan.Hie (countLinesOfCode)
 
@@ -17,4 +17,4 @@ linesOfCodeSpec hieFile = describe "LoC tests" $
 modulesNumSpec :: Int -> Spec
 modulesNumSpec num = describe "Modules number tests" $
     it "should count correct number of modules" $
-        num `shouldBe` 56
+        num `shouldSatisfy` (> 56)


### PR DESCRIPTION
Resolves #171

This was tough :sweat: 

Implemented inspection for finding lazy fields and producing a warning on them. Current limitation: ignores `data` with a single field. HIE AST doesn't track difference between `newtype` and `data`, so some workarounds involved.

TODO:

* Fix warnings for our own code (make all fields strict in all data types). The inspection has already proven itself handy!