### PR TITLE
Update the cabal instructions in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,16 @@ $ git clone https://github.com/kowainik/stan.git
 $ cd stan
 ```
 
-Then, you need to build it using Cabal:
+Then, you need to build and install it using Cabal:
 
 ```shell
-$ cabal v2-build exe:stan
+$ cabal install exe:stan --overwite-policy=always
+```
+
+If you want to simply build and move the binary to a custom location, issue
+
+```shell
+$ cabal build exe:stan
 ```
 
 Finally, you can copy the resulting executable under the desired


### PR DESCRIPTION
Hey folks! installs for cabal work properly as of 3.0, and you can install binaries using the nix-style workflow by issuing 

```shell
cabal install <exe>
```

If you have existing binaries for `stan`, then you can append the flag `--overwrite-policy=always` to blow away the old binary. This is pretty safe to tell people to do in general. Also, `v2-*` prefixes went away in 3.0. I don't imagine people still use the 2.x workflow, since 3.x has been out for more than a year!