### PR TITLE
[#329] Add GHC version to the --version output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The change log is available [on GitHub][2].
 * [#327](https://github.com/kowainik/stan/issues/327):
   When the generated HIE files are incomplete (missing the source code),
   print `<UNAVAILABLE>` as the source instead of failing.
+* [#329](https://github.com/kowainik/stan/issues/329):
+  Add GHC version to the `--version` output.
 
 ## 0.0.0.0
 

--- a/src/Stan/Cli.hs
+++ b/src/Stan/Cli.hs
@@ -36,7 +36,7 @@ import Stan.Category (Category (..))
 import Stan.Config (Check (..), CheckFilter (..), CheckType (..), ConfigP (..), PartialConfig,
                     Scope (..))
 import Stan.Core.Id (Id (..))
-import Stan.Info (prettyStanVersion, stanVersion)
+import Stan.Info (prettyStanVersion, stanVersion, stanSystem)
 import Stan.Inspection (Inspection)
 import Stan.Observation (Observation)
 import Stan.Report.Settings (ReportSettings (..), ToggleSolution (..), Verbosity (..))
@@ -317,7 +317,7 @@ scopeP =
 
 -- | Show the version of the tool.
 versionP :: Parser (a -> a)
-versionP = infoOption (prettyStanVersion stanVersion)
+versionP = infoOption (prettyStanVersion stanVersion stanSystem)
     $ long "version"
     <> short 'v'
     <> help "Show Stan's version"

--- a/src/Stan/Info.hs
+++ b/src/Stan/Info.hs
@@ -51,11 +51,12 @@ stanVersion = StanVersion
 
 {- | Colourful pretty 'StanVersion' representation used in the @CLI@.
 -}
-prettyStanVersion :: StanVersion -> String
-prettyStanVersion StanVersion{..} = toString $ intercalate "\n"
+prettyStanVersion :: StanVersion -> StanSystem -> String
+prettyStanVersion StanVersion{..} StanSystem{..} = toString $ intercalate "\n"
     [ sVersion
     , sHash
     , sDate
+    , sGhc
     ]
   where
     fmt :: String -> String
@@ -65,6 +66,7 @@ prettyStanVersion StanVersion{..} = toString $ intercalate "\n"
     sVersion = fmt $ "Stan " <> "v" <> svVersion
     sHash = " ➤ " <> fmt "Git revision: " <> svGitRevision
     sDate = " ➤ " <> fmt "Commit date:  " <> svCommitDate
+    sGhc  = " ➤ " <> fmt "GHC version:  " <> ssCompilerVersion
 
 {- | Contains all @stan@ System information
 -}


### PR DESCRIPTION
Resolves #329

`base` doesn't include a minor version of GHC. I've created an issue in GHC for further improvements:

* https://gitlab.haskell.org/ghc/ghc/-/issues/18403