### PR TITLE
Fix --inspect-all argument typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ Here is the high-level explanation of the available sub-commands:
 
 | Sub-command | Description | Examples |
 |-------------|-------------|----------|
-| `check` | Set up rules to control the set of inspections per scope. | `stan check --exclude --category=Infinity --scope=all check --include --id "STAN-0101" --file=src/File.hs` |
+| `check` | Set up rules to control the set of inspections per scope. | `stan check --exclude --category=Infinity --scope-all check --include --id "STAN-0101" --file=src/File.hs` |
 | `remove` | Remove some files from the analysis completely. Stan won't be run in the specified scope at all. | `stan remove --file=src/File.hs remove --directory=folder/`         |
 | `ignore` | Ignore specific observation that was found in your project   | `stan ignore --id "OBS-STAN-0001-YrzpQi-11:42"`          |
 


### PR DESCRIPTION
I believe that there's a typo in the table which explains various sub-commands. The given `check` command involves the the `--scope=all` flag, which doesn't exist:

```bash
$ stan check --exclude --category=Infinity --scope=all check --include --id "STAN-0101" --file=src/Main.hs
Invalid option `--scope=all'

Did you mean this?
    --scope-all
```

The `-` and `=` keys are right next to each other, which makes me think it's a typo.

This is my first time contributing. The contributing guidelines say to first create an issue... but this is a minuscule fix (it's a single character!). Please let me know if you'd rather I bundle this with an issue and I will do so.

Thank you for making Stan!