### PR TITLE
Update resolver to the latest LTS

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.1
+resolver: lts-16.9
 
 extra-deps:
 - dir-traverse-0.2.2.3


### PR DESCRIPTION
Just bumping the resolver to the latest LTS available on stackage. Builds fine, and tests are passing.