### PR TITLE
Replace deprecated set-env command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,14 +50,14 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set tag name
-        uses: olegtarasov/get-tag@v2
+        uses: olegtarasov/get-tag@v2.1
         id: tag
         with:
           tagRegex: "v(.*)"
           tagRegexGroup: 1
 
       - name: Setup Haskell
-        uses: haskell/actions/setup@v1
+        uses: haskell/actions/setup@v1.2.1
         id: setup-haskell-cabal
         with:
           ghc-version: ${{ matrix.ghc }}
@@ -80,10 +80,10 @@ jobs:
 
       - if: matrix.os == 'windows-latest'
         name: Set extension to .exe on Windows
-        run: echo "::set-env name=EXT::.exe"
+        run: echo "EXT=.exe" >> $GITHUB_ENV
 
       - name: Set binary path name
-        run: echo "::set-env name=BINARY_PATH::./dist/stan${{ env.EXT }}"
+        run: echo "BINARY_PATH=./dist/prom-docs${{ env.EXT }}" >> $GITHUB_ENV
 
       - name: Compress binary
         uses: svenstaro/upx-action@2.0.1


### PR DESCRIPTION
The release workflow has been broken by removal of `set-env`, `add-path` commands from Github Actions: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

This changes replaced the removed commands with equivalent ones and upgrade dependency that where broken for the same reason.