### PR TITLE
upgrade stack lts to 18.18

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,15 @@
-resolver: lts-17.0
+resolver: lts-18.18
 
 extra-deps:
+- colourista-0.1.0.1
 - dir-traverse-0.2.2.3
+- dlist-0.8.0.8
 - extensions-0.0.0.1
 - microaeson-0.1.0.0
+- optparse-applicative-0.15.1.0
 # When changing relude version, also change it in .github/workflows/ci.yml
 - relude-1.0.0.1
+- slist-0.1.1.0
 - trial-0.0.0.0
 - trial-optparse-applicative-0.0.0.0
 - trial-tomland-0.0.0.0


### PR DESCRIPTION
I upgraded stack lts version to 18.18 to use `stan` on GHC 8.10.7.

I'm not sure I handled correctly the version changes correctly.

Feel free to ditch this PR, or to suggest how to handle things correctly