### PR TITLE
Bump hlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
 
+    - name: Configure
+      run: |
+        cabal configure --enable-tests --enable-benchmarks --test-show-details=direct
+
     - name: Freeze
       run: |
         cabal freeze
@@ -47,7 +51,6 @@ jobs:
 
     - name: Build
       run: |
-        cabal configure --enable-tests --enable-benchmarks --test-show-details=direct
         cabal build all
 
     - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,10 @@ jobs:
     name: ${{ matrix.os }} / ghc ${{ matrix.ghc }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        cabal: ["3.2"]
+        cabal: ["3.10"]
         ghc:
           - "8.8.4"
           - "8.10.4"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: haskell/actions/setup@v2.0.1
+    - uses: haskell/actions/setup@v2.4.6
       id: setup-haskell-cabal
       name: Setup Haskell
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
 
     - name: Run HLint
       env:
-         HLINT_VERSION: "3.2.7"
+         HLINT_VERSION: "3.6.1"
       run: |
         curl https://raw.githubusercontent.com/kowainik/relude/v1.0.0.1/.hlint.yaml -o .hlint-relude.yaml
 

--- a/src/Stan/Report/Css.hs
+++ b/src/Stan/Report/Css.hs
@@ -1,3 +1,5 @@
+{- HLINT ignore "Use zipWithM_" -}
+
 {-# LANGUAGE PostfixOperators #-}
 
 {- |

--- a/test/Test/Stan/Analysis/Partial.hs
+++ b/test/Test/Stan/Analysis/Partial.hs
@@ -45,8 +45,6 @@ analysisPartialSpec analysis = describe "Partial functions" $ do
         end = start + funLen
 
     checkObservationFor :: Inspection -> Int -> Int -> Int -> Expectation
-    checkObservationFor ins line start end = observationAssert
+    checkObservationFor= observationAssert
         ["Partial"]
         analysis
-        ins
-        line start end


### PR DESCRIPTION
Old version fails with:

./hlint-3.2.7/hlint: error while loading shared libraries: libtinfo.so.5: cannot open shared object file: No such file or directory