### PR TITLE
Bump olegtarasov/get-tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set tag name
-        uses: olegtarasov/get-tag@v2
+        uses: olegtarasov/get-tag@v2.1.2
         id: tag
         with:
           tagRegex: "v(.*)"


### PR DESCRIPTION
Because the older version was using deprecated functionality.  The error message was:

Error: Unable to process command '##[set-env
name=GIT_TAG_NAME;]0.1.0.0' successfully.

Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/