### PR TITLE
Bump `stack.yaml`, include in sdist file

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,16 +1,15 @@
-resolver: lts-18.18
+resolver: lts-21.15 # GHC 9.4.7
 
 extra-deps:
-- colourista-0.1.0.1
-- dir-traverse-0.2.2.3
-- dlist-0.8.0.8
-- extensions-0.0.0.1
-- microaeson-0.1.0.0
-- optparse-applicative-0.15.1.0
-# When changing relude version, also change it in .github/workflows/ci.yml
-- relude-1.0.0.1
-- slist-0.1.1.0
-- trial-0.0.0.0
-- trial-optparse-applicative-0.0.0.0
-- trial-tomland-0.0.0.0
-- clay-0.14.0
+- clay-0.14.0@sha256:a50ba73137a39c55e89f24a7792107ec40ba07320b2c5ff7932049845c50ffc9,2204
+- dir-traverse-0.2.3.0@sha256:adcc128f201ff95131b15ffe41365dc99c50dc3fa3a910f021521dc734013bfa,2137
+- extensions-0.1.0.0@sha256:b8105dc43a57b0b3b54879e8dbb905676dfee3e8b59301fefbf2409a0fe95710,4447
+- hedgehog-1.1.2@sha256:7378b26898f39ec436da93a95112db271384a2fe517bf8323c4e5893ea461b78,4475
+- optparse-applicative-0.16.1.0@sha256:418c22ed6a19124d457d96bc66bd22c93ac22fad0c7100fe4972bbb4ac989731,4982
+- pretty-simple-4.0.0.0@sha256:a65be4ef40734eae1da7a88c9b73dbf1848f5a60b634dc4776fae60cafc85386,4071
+- primitive-0.7.4.0@sha256:c2f0ed97b3dce97f2f43b239c3be8b136e4368f1eb7b61322ee9ac98f604622b,2982
+- tomland-1.3.3.2@sha256:d18682d9ad9014cc42a12bd122ae7834a950a052a122388995f33d6f349ff60d,9235
+- trial-0.0.0.0@sha256:7946afde7134db6c5c35b7ab611018e2925e9c9fbb8c0fcf9831f3c7020928f1,4416
+- trial-optparse-applicative-0.0.0.0@sha256:92548124f12c746bd30bb19c2e57b8a1bcad5824980f04a387efb0b1487c053c,2478
+- trial-tomland-0.0.0.0@sha256:77f63a62660f94774375b2c1a1b28d25e4791d9bcad05e33dd7597cff0e75beb,2547
+- validation-selective-0.2.0.0@sha256:e847f5aeb078414d22677e6fe1760355ea3bbafc116fa4a9c8bce7f2c3dbcb54,3801

--- a/stan.cabal
+++ b/stan.cabal
@@ -17,6 +17,7 @@ build-type:          Simple
 stability:           experimental
 extra-doc-files:     README.md
                      CHANGELOG.md
+                     stack.yaml
 extra-source-files:  test/.stan-example.toml
 tested-with:         GHC == 8.8.4
                      GHC == 8.10.7


### PR DESCRIPTION
`stack.yaml` is bumped to GHC 9.4.7, the most recent version of GHC supported by the tool.

`stack.yaml` is incuded in the sdist file. This will help Stack users install the tool from Hackage.

(As an aside, the current `stack.yaml` file will not work because it does not set the flags required for its `mintty` dependency. That falls away if this pull request is adopted.)