### PR TITLE
Changes to avoid GHC warnings on building

### DIFF
--- a/src/Stan/Ghc/Compat810.hs
+++ b/src/Stan/Ghc/Compat810.hs
@@ -71,5 +71,5 @@ import qualified Data.Text as T
 showTUnitId :: UnitId -> Text
 showTUnitId = T.pack . unitIdString
 #else
-  where
+  () where
 #endif

--- a/src/Stan/Hie.hs
+++ b/src/Stan/Hie.hs
@@ -16,6 +16,7 @@ module Stan.Hie
     ) where
 
 import Colourista (errorMessage, infoMessage, warningMessage)
+import Prelude hiding (span)
 import System.Directory (doesDirectoryExist, doesFileExist)
 import System.Directory.Recursive (getDirRecursive)
 import System.FilePath (takeExtension)

--- a/src/Stan/Pattern/Ast.hs
+++ b/src/Stan/Pattern/Ast.hs
@@ -190,6 +190,7 @@ foo :: Some -> Type
 typeSig :: PatternAst
 typeSig = PatternAstNode $ one (mkNodeAnnotation "TypeSig" "Sig")
 
+absBinds :: NodeAnnotation
 absBinds =
 #if __GLASGOW_HASKELL__ < 904
   mkNodeAnnotation "AbsBinds" "HsBindLR"

--- a/src/Stan/Pattern/Type.hs
+++ b/src/Stan/Pattern/Type.hs
@@ -107,6 +107,7 @@ listFunPattern :: PatternType
 listFunPattern = listPattern |-> (?)
 
 -- | 'PatternType' for 'Integer'.
+integerPattern :: PatternType
 integerPattern =
 #if __GLASGOW_HASKELL__ < 900
   integerPattern810
@@ -115,6 +116,7 @@ integerPattern =
 #endif
 
 -- | 'PatternType' for 'Natural'.
+naturalPattern :: PatternType
 naturalPattern =
 #if __GLASGOW_HASKELL__ < 900
   naturalPattern810


### PR DESCRIPTION
These changes avoid almost all GHC warnings on building. The one warning I could not work out how to avoid was:
~~~text
<no location info>: warning: [-Wunused-packages]
    The following packages were specified via -package or -package-id flags,
    but were not needed for compilation:
      - base-4.17.2.0 (exposed by flag -package-id base-4.17.2.0)
~~~