### PR TITLE
Revisit Stack-related CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,40 +87,37 @@ jobs:
       run: |
         cabal run stan
 
+  # As at 2023-10-15, the GitHub-hosted runner for ubuntu-latest comes with
+  # Stack 2.13.1 and GHC 9.6.3.
   stack:
     name: stack / ghc ${{ matrix.ghc }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        stack: ["2.5"]
-        ghc: ["8.10.7"]
+        ghc: ["9.4.7"] # The version specified in the stack.yaml file
+        cache-bust: ["2023-10-15"]
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Clone project
+      uses: actions/checkout@v4
 
-    - uses: haskell/actions/setup@v2.4.7
-      name: Setup Haskell Stack
-      with:
-        ghc-version: ${{ matrix.ghc }}
-        stack-version: ${{ matrix.stack }}
-
-    - uses: actions/cache@v3.3.2
-      name: Cache ~/.stack
+    - name: Cache the Stack root
+      uses: actions/cache@v3
       with:
         path: ~/.stack
-        key: ${{ runner.os }}-${{ matrix.ghc }}-stack
+        key: ${{ runner.os }}-${{ hashFiles('stack.yaml') }}-${{ matrix.cache-bust }}
 
-    - name: Build
+    - name: Build everything
       run: |
-        stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks
+        stack build --test --bench --no-run-tests --no-run-benchmarks
 
-    - name: Test
+    - name: Run test-suites
       run: |
-        stack test --system-ghc
+        stack test
 
-    - name: Dogfooding
+    - name: Apply built stan to stan
       run: |
-        stack run stan --system-ghc
+        stack exec -- stan --cabal-file-path stan.cabal
 
   hlint:
     name: hlint


### PR DESCRIPTION
To explain:

* Bumps to GHC 9.4.7 (the version specified by the `stack.yaml`).
* Adds a 'cache-bust' to the caching key (in case it is needed in the future).
* Uses the stack.yaml for the key, not the GHC version.
* Uses the Stack-supplied GHC (which will be cached). `--system-ghc` does nothing, if the system's GHC is not the version that Stack requires. So, Stack will have been fetching the required GHC in any event (given the `stack.yaml`).
* Uses `stack exec` rather than `stack run`, as we know the executable has already been built.
* Specifies `--cabal-file-path stan.cabal` in case other Cabal files are added in the future and to save stan from searching for Cabal files.