### PR TITLE
Support GHC 9.8

### DIFF
--- a/src/Stan/Ghc/Compat.hs
+++ b/src/Stan/Ghc/Compat.hs
@@ -12,4 +12,6 @@ import Stan.Ghc.Compat902 as Compat
 import Stan.Ghc.Compat902 as Compat
 #elif __GLASGOW_HASKELL__ == 906
 import Stan.Ghc.Compat906 as Compat
+#elif __GLASGOW_HASKELL__ == 908
+import Stan.Ghc.Compat906 as Compat
 #endif

--- a/src/Stan/Ghc/Compat906.hs
+++ b/src/Stan/Ghc/Compat906.hs
@@ -4,7 +4,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Stan.Ghc.Compat906
-#if __GLASGOW_HASKELL__ == 906
+#if __GLASGOW_HASKELL__ == 906 || __GLASGOW_HASKELL__ == 908
     ( -- * Modules
       Module
     , ModuleName

--- a/src/Stan/Hie/Compat.hs
+++ b/src/Stan/Hie/Compat.hs
@@ -12,4 +12,6 @@ import Stan.Hie.Compat902 as Compat
 import Stan.Hie.Compat904 as Compat
 #elif __GLASGOW_HASKELL__ == 906
 import Stan.Hie.Compat904 as Compat
+#elif __GLASGOW_HASKELL__ == 908
+import Stan.Hie.Compat904 as Compat
 #endif

--- a/src/Stan/Hie/Compat904.hs
+++ b/src/Stan/Hie/Compat904.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 
 module Stan.Hie.Compat904
-#if __GLASGOW_HASKELL__ == 904 || __GLASGOW_HASKELL__ == 906
+#if __GLASGOW_HASKELL__ == 904 || __GLASGOW_HASKELL__ == 906 || __GLASGOW_HASKELL__ == 908
     ( -- * Main HIE types
       ContextInfo (..)
     , HieArgs (..)

--- a/src/Stan/Hie/Debug.hs
+++ b/src/Stan/Hie/Debug.hs
@@ -12,4 +12,6 @@ import Stan.Hie.Debug902 as Compat
 import Stan.Hie.Debug902 as Compat
 #elif __GLASGOW_HASKELL__ == 906
 import Stan.Hie.Debug902 as Compat
+#elif __GLASGOW_HASKELL__ == 908
+import Stan.Hie.Debug902 as Compat
 #endif

--- a/src/Stan/Hie/Debug902.hs
+++ b/src/Stan/Hie/Debug902.hs
@@ -21,7 +21,7 @@ package to dependencies and use the @pPrint@ function from the
 -}
 
 module Stan.Hie.Debug902
-#if __GLASGOW_HASKELL__ == 902 || __GLASGOW_HASKELL__ == 904 || __GLASGOW_HASKELL__ == 906
+#if __GLASGOW_HASKELL__ == 902 || __GLASGOW_HASKELL__ == 904 || __GLASGOW_HASKELL__ == 906 || __GLASGOW_HASKELL__ == 908
     ( debugHieFile
     ) where
 

--- a/stan.cabal
+++ b/stan.cabal
@@ -27,7 +27,7 @@ source-repository head
   location:            https://github.com/kowainik/stan.git
 
 common common-options
-  build-depends:       base >= 4.13 && < 4.19 && (< 4.16.3.0 || >= 4.17)
+  build-depends:       base >= 4.13 && < 4.20 && (< 4.16.3.0 || >= 4.17)
                        -- ^^ .hie files don't contain enough type
                        -- information on ghc-9.2.[4-8] (base >=
                        -- 4.16.3.0 && < 4.17)
@@ -72,6 +72,7 @@ common common-relude
 
 library
   import:              common-options
+
                      , common-relude
   hs-source-dirs:      src
   exposed-modules:     Stan
@@ -143,7 +144,7 @@ library
                      , extensions ^>= 0.0.0.1 || ^>= 0.1.0.0
                      , filepath ^>= 1.4
                      , ghc >= 8.8 && < 9.7
-                     , ghc-boot-th >= 8.8 && < 9.7
+                     , ghc-boot-th >= 8.8 && < 9.9
                      , gitrev ^>= 1.3.1
                      , microaeson ^>= 0.1.0.0
                      , optparse-applicative >= 0.15 && < 0.17


### PR DESCRIPTION
- Bump dependencies.
- Add Debug908.hs
- Fix renaming of `(,)` to `Tuple2` from `GHC.Tuple.Prim` (https://hackage.haskell.org/package/ghc-prim-0.11.0/docs/GHC-Tuple-Prim.html#t:Tuple2)
- Set conditional `--allow-newer` for ci