### PR TITLE
Remove CI special case for GHC 9.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,21 +53,14 @@ jobs:
         cabal-version: ${{ matrix.cabal }}
         cabal-update: true
 
-    - name: Set envvar EXTRA_FLAGS
-      shell: bash
-      if: ${{ matrix.ghc == '9.8.1' }}
-      run: |
-        echo "EXTRA_FLAGS=--allow-newer" >> "$GITHUB_ENV"
-
     # Tom says: I'm not sure whether it's correct to configure before
     # freezing because it might defeat the point of caching. However,
     # configuring *after* freezing seemed to mean that the cache got
     # stuck in some bad state where it couldn't find a build plan.  We
     # should revisit this decision later.
     - name: Configure
-      shell: bash
       run: |
-        cabal configure --enable-tests --enable-benchmarks --test-show-details=direct $EXTRA_FLAGS
+        cabal configure --enable-tests --enable-benchmarks --test-show-details=direct
         # Generate dist-newstyle/cache/plan.json for the cache key.
         cabal build --dry-run
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        cabal: ["3.8"]
+        cabal: ["3.10"]
         ghc:
           - "8.8.4"
           - "8.10.7"


### PR DESCRIPTION
Closes https://github.com/kowainik/stan/issues/535

This removes the special case code added in
aff7e69d671d22fde0a0236e6bd511804c0605af because at that time stan's depedencies had not yet had their bounds adjusted to support GHC 9.8. Now they do support 9.8 so we can remove the special case.