### PR TITLE
Bump clay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 `stan` uses [PVP Versioning][1].
 The change log is available [on GitHub][2].
 
+## 0.1.2.0
+
+* Added `runStan`, `getAnalysis`, `getStanConfig`
+
 ## 0.1.1.0
 
 * Fix [bug #541](https://github.com/kowainik/stan/issues/541)

--- a/src/Stan/Report/Css.hs
+++ b/src/Stan/Report/Css.hs
@@ -297,7 +297,8 @@ grid = do
     w :: NonEmpty Rational
     w = 4.33 :| [12.66, 21, 29.33, 37.66, 46, 54.33, 62.66, 71, 79.33, 87.66, 96]
 
-    mediaQuery :: Double -> Css -> Css
+    -- clay-0.14: mediaQuery :: Double -> Css -> Css
+    -- clay-0.15: mediaQuery :: Number -> Css -> Css
     mediaQuery x = query M.screen [M.minWidth (em x)]
 
 marginAuto :: Css

--- a/stan.cabal
+++ b/stan.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                stan
-version:             0.1.1.0
+version:             0.1.2.0
 synopsis:            Haskell STatic ANalyser
 description:
     Stan is a Haskell __ST__atic __AN__alysis CLI tool.

--- a/stan.cabal
+++ b/stan.cabal
@@ -138,7 +138,7 @@ library
                      , base64 ^>= 0.4.1
                      , blaze-html ^>= 0.9.1
                      , bytestring >= 0.10 && < 0.13
-                     , clay ^>= 0.14
+                     , clay >= 0.14 && < 0.16
                      , colourista >= 0.1 && < 0.3
                      , containers >= 0.5 && < 0.7
                      , cryptohash-sha1 ^>= 0.11


### PR DESCRIPTION
(And also include the version bump to `v0.1.2.0`, which is currently on a tag which forked from `main`, for some reason.)