### PR TITLE
Bump stack.yaml to GHC 9.6.4/lts-22.7

### DIFF
--- a/stack-ghc-9.6.3.yaml
+++ b/stack-ghc-9.6.3.yaml
@@ -1,4 +1,4 @@
-resolver: lts-22.7 # GHC 9.6.4
+resolver: lts-22.6 # GHC 9.6.3
 
 extra-deps:
 - ansi-wl-pprint-0.6.9@sha256:fb737bc96e2aef34ad595d54ced7a73f648c521ebcb00fe0679aff45ccd49212,2448

--- a/stan.cabal
+++ b/stan.cabal
@@ -19,6 +19,7 @@ extra-doc-files:     README.md
                      CHANGELOG.md
 extra-source-files:  test/.stan-example.toml
                      stack-ghc-9.4.8.yaml
+                     stack-ghc-9.6.3.yaml
                      stack.yaml
 tested-with:         GHC == 8.8.4
                      GHC == 8.10.7


### PR DESCRIPTION
Also bumps old `stack.yaml` to `lts-22.6` (the last for GHC 9.6.3) and preserves it, for people using Stan with GHC 9.6.3 and Stack in CI.