### PR TITLE
Bump stack.yaml to GHC 9.6.5/lts-22.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,15 +98,15 @@ jobs:
       run: |
         cabal run stan
 
-  # As at 2023-12-16, the GitHub-hosted runner for ubuntu-latest comes with
-  # Stack 2.13.1 and GHC 9.8.1.
+  # As at 2024-05-06, the GitHub-hosted runner for ubuntu-latest comes with
+  # Stack 2.15.5 and GHC 9.8.2.
   stack:
     name: stack / ghc ${{ matrix.ghc }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ["9.6.3"] # The version specified in the stack.yaml file
-        cache-bust: ["2023-12-16"]
+        ghc: ["9.6.5"] # The version specified in the stack.yaml file
+        cache-bust: ["2024-05-06"]
 
     steps:
     - name: Clone project

--- a/stack-ghc-9.6.4.yaml
+++ b/stack-ghc-9.6.4.yaml
@@ -1,4 +1,4 @@
-resolver: lts-22.6 # GHC 9.6.3
+resolver: lts-22.20 # GHC 9.6.4
 
 extra-deps:
 - ansi-wl-pprint-0.6.9@sha256:fb737bc96e2aef34ad595d54ced7a73f648c521ebcb00fe0679aff45ccd49212,2448

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,9 @@
-resolver: lts-22.7 # GHC 9.6.4
+resolver: lts-22.21 # GHC 9.6.5
 
 extra-deps:
 - ansi-wl-pprint-0.6.9@sha256:fb737bc96e2aef34ad595d54ced7a73f648c521ebcb00fe0679aff45ccd49212,2448
 - dir-traverse-0.2.3.0@sha256:adcc128f201ff95131b15ffe41365dc99c50dc3fa3a910f021521dc734013bfa,2137
-- extensions-0.1.0.1@sha256:f365d1da5ea1c60edd11334113ecd0d78eb12b4186b31151322ff7175a9adef7,5108
+- extensions-0.1.0.1@sha256:131270f3dd3adfa96e48259a200b7303c4f8211f54bff168fb8020dfef2aaec7,5269
 - optparse-applicative-0.17.1.0@sha256:cb5f5f0dc9749846fc0e3df0041a8efee6368cc1cff07336acd4c3b02a951ed6,5147
 - tomland-1.3.3.2@sha256:887dc39a8c9819deb8fcb6fde72e87dad4c94108b1736a5bf7215ccf3117bd0f,9474
 - trial-0.0.0.0@sha256:ebd93f3485dd7f0ce8426fa46b500f26edbea285c2890150123e1b0f6a92c7db,4410

--- a/stan.cabal
+++ b/stan.cabal
@@ -20,6 +20,7 @@ extra-doc-files:     README.md
 extra-source-files:  test/.stan-example.toml
                      stack-ghc-9.4.8.yaml
                      stack-ghc-9.6.3.yaml
+                     stack-ghc-9.6.4.yaml
                      stack.yaml
 tested-with:         GHC == 8.8.4
                      GHC == 8.10.7


### PR DESCRIPTION
Also bumps old `stack.yaml` to `lts-22.20` (the last for GHC 9.6.4) and preserves it, for people using Stack with GHC 9.6.4 and Stack in CI.

Also updates `stack-ghc-9.6.3.yaml` for Cabal file revisions made to `extensions-0.1.0.1`.

Also bumps the Stack-related part of the CI.