### PR TITLE
Warning about overzealous -Wunused-packages

### DIFF
--- a/stan.cabal
+++ b/stan.cabal
@@ -49,6 +49,8 @@ common common-options
                        -fwrite-ide-info
                        -hiedir=.hie
   if impl(ghc >= 8.10)
+    -- WARNING: This warning reports false positives.
+    -- SEE: https://gitlab.haskell.org/ghc/ghc/-/issues/24173
     ghc-options:       -Wunused-packages
 
   default-language:    Haskell2010


### PR DESCRIPTION
I had a go a fixing this by only depending on base in components that needed it. After commenting out all other components except the main library, I found that base was needed and the `-Wunused-packages` warning was a false positive. Rather than removed the `-Wunused-packages` warning, I opted to leave a comment pointing to the relevant GHC issue.

