### PR TITLE
Avoid -Wname-shadowing with Text.Blaze.Html5.s

### DIFF
--- a/src/Stan/Report/Html.hs
+++ b/src/Stan/Report/Html.hs
@@ -376,9 +376,9 @@ stanSeverityExplained = do
         traverse_ toSeverityRow (universe @Severity)
   where
     toSeverityRow :: Severity -> Html
-    toSeverityRow s = tr $ do
-        td (severity $ show s)
-        td (toHtml $ severityDescription s)
+    toSeverityRow sv = tr $ do
+        td (severity $ show sv)
+        td (toHtml $ severityDescription sv)
 
 stanFooter :: Html
 stanFooter = footer $ do


### PR DESCRIPTION
For the `ghc-9.10.1` build we can pick up `blaze-html-0.9.2.0` but with it get a `-Wname-shadowing` warning. This fixes that and I opted to rename `s` locally rather than use `CPP` with the import.

https://hackage.haskell.org/package/blaze-html-0.9.2.0/changelog

https://hackage.haskell.org/package/blaze-html-0.9.2.0/docs/Text-Blaze-Html4-FrameSet.html#v:s