### PR TITLE
[#578] Adds inspections for partial `Scientific` functions

### DIFF
--- a/src/Stan/Pattern/Type.hs
+++ b/src/Stan/Pattern/Type.hs
@@ -24,6 +24,8 @@ module Stan.Pattern.Type
     , listFunPattern
     , integerPattern
     , naturalPattern
+    , rationalPattern
+    , scientificPattern
 
       -- ** Textual types
     , charPattern
@@ -157,6 +159,24 @@ naturalPattern = NameMeta
     } |:: []
 
 #endif
+
+rationalPattern :: PatternType
+rationalPattern =
+  "Rational" `_nameFrom` moduleName |:: []
+  where
+    moduleName =
+#if __GLASGOW_HASKELL__ >= 910
+      "GHC.Internal.Real"
+#else
+      "GHC.Real"
+#endif
+
+scientificPattern :: PatternType
+scientificPattern = NameMeta
+    { nameMetaName = "Scientific"
+    , nameMetaModuleName = "Data.Scientific"
+    , nameMetaPackage = "scientific"
+    } |:: []
 
 charPattern :: PatternType
 charPattern = primTypeMeta "Char" |:: []

--- a/stan.cabal
+++ b/stan.cabal
@@ -174,6 +174,7 @@ library target
   hs-source-dirs:      target
   build-depends:       bytestring
                      , filepath
+                     , scientific
                      , text
                      , unordered-containers
   exposed-modules:     Target.AntiPattern

--- a/target/Target/Partial.hs
+++ b/target/Target/Partial.hs
@@ -8,6 +8,7 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.Maybe (fromJust)
 import GHC.Exts (fromList)
 import Numeric.Natural (Natural)
+import Data.Scientific (Scientific)
 
 import qualified Data.List.NonEmpty as NE
 
@@ -74,6 +75,18 @@ stanFromList = fromList
 
 stanFromInteger :: Integer -> Natural
 stanFromInteger = fromInteger
+
+stanFromRational :: Rational -> Scientific
+stanFromRational = fromRational
+
+stanRealToFrac :: Real a => a -> Scientific
+stanRealToFrac = realToFrac
+
+stanRecip :: Scientific -> Scientific
+stanRecip = recip
+
+stanDivide :: Scientific -> Scientific -> Scientific
+stanDivide a b = a / b
 
 -- Other tests
 

--- a/test/Test/Stan/Analysis.hs
+++ b/test/Test/Stan/Analysis.hs
@@ -57,7 +57,7 @@ analysisIgnoredObservationsSpec
     :: ([Id Observation] -> Analysis)  -- ^ Run analysis with ignored observations
     -> Spec
 analysisIgnoredObservationsSpec analyse = describe "Ignores observations" $ do
-    let obsId = Id "OBS-STAN-0001-pnvTKA-16:12"
+    let obsId = Id "OBS-STAN-0001-pnvTKA-17:12"
 
     it "ObservationId is present when not ignored " $ do
         let observationsIds = fmap observationId $ analysisObservations $ analyse []

--- a/test/Test/Stan/Analysis/Partial.hs
+++ b/test/Test/Stan/Analysis/Partial.hs
@@ -18,18 +18,18 @@ import qualified Stan.Inspection.Partial as Partial
 
 analysisPartialSpec :: Analysis -> Spec
 analysisPartialSpec analysis = describe "Partial functions" $ do
-    forM_ (zip (sortById partialInspectionsMap) [16, 19 ..]) checkObservation
+    forM_ (zip (sortById partialInspectionsMap) [17, 20 ..]) checkObservation
 
     let noObservation = noObservationAssert ["Partial"] analysis
 
     it "STAN-0010: doesn't trigger on 'succ :: Natural -> Natural'" $
-        noObservation Partial.stan0010 81
+        noObservation Partial.stan0010 94
     it "STAN-0011: doesn't trigger on 'pred :: Integer -> Integer'" $
-        noObservation Partial.stan0011 84
+        noObservation Partial.stan0011 97
     it "STAN-0011: triggers on polymorphic 'pred :: Enum a => a -> a'" $
-        checkObservationFor Partial.stan0011 87 16 20
+        checkObservationFor Partial.stan0011 100 16 20
     it "STAN-0020: triggers on 'Data.List.NonEmpty.fromList'" $
-        checkObservationFor Partial.stan0020 90 18 29
+        checkObservationFor Partial.stan0020 103 18 29
 
   where
     checkObservation :: (Inspection, Int) -> SpecWith (Arg Expectation)
@@ -41,7 +41,10 @@ analysisPartialSpec analysis = describe "Partial functions" $ do
 
         funLen, start, end :: Int
         funLen = T.length $ nameMetaName nameMeta
-        start = if nameMetaName nameMeta == "!!" then funLen + 14 else funLen + 8
+        start = funLen + case nameMetaName nameMeta of
+          "!!" -> 14
+          "/" -> 19
+          _ -> 8
         end = start + funLen
 
     checkObservationFor :: Inspection -> Int -> Int -> Int -> Expectation

--- a/test/Test/Stan/Number.hs
+++ b/test/Test/Stan/Number.hs
@@ -12,7 +12,7 @@ import Stan.Hie (countLinesOfCode)
 linesOfCodeSpec :: HieFile -> Spec
 linesOfCodeSpec hieFile = describe "LoC tests" $
     it "should count lines of code in the example file" $
-        countLinesOfCode hieFile `shouldBe` 90
+        countLinesOfCode hieFile `shouldBe` 103
 
 modulesNumSpec :: Int -> Spec
 modulesNumSpec num = describe "Modules number tests" $


### PR DESCRIPTION
I added four new inspections, all relating to functions on `Scientific` from the `scientific` package that are partial due to potentially repeating decimals:

- STAN-0022 `fromRational :: Rational -> Scientific`
- STAN-0023 `realToFrac :: Real a => a -> Scientific`
- STAN-0024 `recip :: Scientific -> Scientific`
- STAN-0025 `(/) :: Scientific -> Scientific -> Scientific`