### PR TITLE
Improve finding cabal files

### DIFF
--- a/src/Stan/Cabal.hs
+++ b/src/Stan/Cabal.hs
@@ -98,9 +98,8 @@ findCabalFileDir dir = do
     dirContent <- listDirectory dir
     let cabalFiles = filter isCabal dirContent
     pure $ case cabalFiles of
-        []          -> Nothing -- throwError $ NoCabalFile dirPath
-        [cabalFile] -> Just $ dir </> cabalFile
-        x:_xs       -> Just x -- throwError $ MultipleCabalFiles (x :| xs)
+        []            -> Nothing
+        cabalFile : _ -> Just $ dir </> cabalFile
   where
     isCabal :: FilePath -> Bool
     isCabal p = takeExtension p == ".cabal"

--- a/src/Stan/Cabal.hs
+++ b/src/Stan/Cabal.hs
@@ -120,6 +120,7 @@ getSubdirsRecursive fp = do
            d /= "dist"
         && d /= "dist-newstyle"
         && d /= ".stack-work"
+        && d /= ".git"
 
     mkRel :: FilePath -> FilePath
     mkRel = (fp </>)

--- a/stan.cabal
+++ b/stan.cabal
@@ -149,6 +149,7 @@ library
                      , cryptohash-sha1 ^>= 0.11
                      , dir-traverse ^>= 0.2.2.2
                      , directory ^>= 1.3
+                     , directory-ospath-streaming ^>= 0.2
                      , extensions ^>= 0.0.0.1 || ^>= 0.1.0.0
                      , filepath >= 1.4 && < 1.6
                      , ghc >= 8.8 && < 9.13


### PR DESCRIPTION
Should fix https://github.com/haskell/haskell-language-server/issues/4515#issuecomment-2806627537

I did a quick benchmark to try out the suggestion to use [directory-ospath-streaming](https://hackage-content.haskell.org/package/directory-ospath-streaming-0.2.2/docs/System-Directory-OsPath-Streaming.html#v:listContentsRecFold), with this results:

```
benchmarking findCabalFiles/streaming
time                 227.6 ms   (194.2 ms .. 259.8 ms)
                     0.990 R²   (0.965 R² .. 1.000 R²)
mean                 277.9 ms   (252.6 ms .. 349.6 ms)
std dev              53.94 ms   (1.425 ms .. 67.77 ms)
variance introduced by outliers: 57% (severely inflated)
benchmarking findCabalFiles/original ospath
time                 370.2 ms   (313.7 ms .. 434.7 ms)
                     0.996 R²   (0.987 R² .. 1.000 R²)
mean                 391.7 ms   (377.1 ms .. 406.2 ms)
std dev              18.44 ms   (9.247 ms .. 22.70 ms)
variance introduced by outliers: 19% (moderately inflated)
benchmarking findCabalFiles/original filepath
time                 681.7 ms   (622.5 ms .. 749.8 ms)
                     0.999 R²   (0.996 R² .. 1.000 R²)
mean                 689.1 ms   (676.5 ms .. 700.1 ms)
std dev              13.06 ms   (11.07 ms .. 14.55 ms)
variance introduced by outliers: 19% (moderately inflated)
```

and this code:

<details><summary>`bench/Main.hs`</summary>
<p>


```haskell
{-# LANGUAGE QuasiQuotes #-}
module Main (main) where

import Criterion.Main
import Stan.Cabal (findCabalFiles, findCabalFilesStreaming, findCabalFilesFilePath)
import System.Directory.OsPath (setCurrentDirectory)
import System.OsPath (osp)

main :: IO ()
main = do
  setCurrentDirectory [osp|../haskell-language-server/|] -- here i have the extra 100,000 files + hls
  defaultMain
    [ bgroup
        "findCabalFiles"
        [ bench "streaming" $ nfIO findCabalFilesStreaming,
          bench "original ospath" $ nfIO findCabalFiles,
          bench "original filepath" $ nfIO findCabalFilesFilePath
        ]
    ]
```



</p>
</details> 

<details><summary>`src/Stan/Cabal.hs`</summary>
<p>


```haskell

{- | Recursively find all @.cabal@ files in the current directory and its
subdirectories. It returns maximum 1 @.cabal@ file from each directory.
-}
findCabalFiles :: IO [FilePath]
findCabalFiles = do
    dir <- getCurrentDirectory
    curDirCabal <- findCabalFileDir dir
    dirs <- getSubdirsRecursive dir
    subDirsCabals <- mapM findCabalFileDir dirs
    pure $ catMaybes $ curDirCabal : subDirsCabals

-- | Find a @.cabal@ file in the given directory.
-- TODO: better error handling in stan.
findCabalFileDir :: FilePath -> IO (Maybe FilePath)
findCabalFileDir dir = do
    dirContent <- listDirectory dir
    let cabalFiles = filter isCabal dirContent
    pure $ case cabalFiles of
        []            -> Nothing
        cabalFile : _ -> Just $ dir </> cabalFile
  where
    isCabal :: FilePath -> Bool
    isCabal p = takeExtension p == ".cabal"

getSubdirsRecursive :: FilePath -> IO [FilePath]
getSubdirsRecursive fp = do
    f <- OsPath.encodeFS fp
    res <- getSubdirsRecursiveOs f
    traverse OsPath.decodeFS res

getSubdirsRecursiveOs :: OsPath.OsPath -> IO [OsPath.OsPath]
getSubdirsRecursiveOs fp = do
    all' <- filter nonGenDir <$> OsPath.listDirectory fp
    dirs <- filterM OsPath.doesDirectoryExist (mkRel <$> all')
    case dirs of
        [] -> pure []
        ds -> do
            -- unsafeInterleaveIO is required here for performance reasons
            next <- unsafeInterleaveIO $ foldMapA getSubdirsRecursiveOs ds
            pure $ dirs ++ next
  where
    nonGenDir :: OsPath.OsPath -> Bool
    nonGenDir d =
           d /= [OsPath.osp|dist|]
        && d /= [OsPath.osp|dist-newstyle|]
        && d /= [OsPath.osp|.stack-work|]
        && d /= [OsPath.osp|.git|]

    mkRel :: OsPath.OsPath -> OsPath.OsPath
    mkRel = (fp OsPath.</>)


{- | Recursively find all @.cabal@ files in the current directory and its
subdirectories. It returns maximum 1 @.cabal@ file from each directory.
-}
findCabalFilesFilePath :: IO [FilePath]
findCabalFilesFilePath = do
    dir <- getCurrentDirectory
    curDirCabal <- findCabalFileDirFilePath dir
    dirs <- getSubdirsRecursiveFilePath dir
    subDirsCabals <- mapM findCabalFileDirFilePath dirs
    pure $ catMaybes $ curDirCabal : subDirsCabals

-- | Find a @.cabal@ file in the given directory.
-- TODO: better error handling in stan.
findCabalFileDirFilePath :: FilePath -> IO (Maybe FilePath)
findCabalFileDirFilePath dir = do
    dirContent <- listDirectory dir
    let cabalFiles = filter isCabal dirContent
    pure $ case cabalFiles of
        []            -> Nothing
        cabalFile : _ -> Just $ dir </> cabalFile
  where
    isCabal :: FilePath -> Bool
    isCabal p = takeExtension p == ".cabal"

getSubdirsRecursiveFilePath :: FilePath -> IO [FilePath]
getSubdirsRecursiveFilePath fp = do
    all' <- filter nonGenDir <$> listDirectory fp
    dirs <- filterM doesDirectoryExist (mkRel <$> all')
    case dirs of
        [] -> pure []
        ds -> do
            -- unsafeInterleaveIO is required here for performance reasons
            next <- unsafeInterleaveIO $ foldMapA getSubdirsRecursiveFilePath ds
            pure $ dirs ++ next
  where
    nonGenDir :: FilePath -> Bool
    nonGenDir d =
           d /= "dist"
        && d /= "dist-newstyle"
        && d /= ".stack-work"

    mkRel :: FilePath -> FilePath
    mkRel = (fp </>)

findCabalFilesStreaming :: IO [FilePath]
findCabalFilesStreaming = do
    setRef <- IORef.newIORef S.empty -- stores the directories where we already found 1 cabal file
    root <- OsPath.getCurrentDirectory
    traverse OsPath.decodeFS =<<
        OPS.listContentsRecFold
           Nothing -- Depth limit
            (\_ _ (OPS.Relative _dirRelPath) (OPS.Basename dirBasename)  _symlinkType _consDirToList traverseThisSubdir rest ->
                 if visitCurrSubdirPred dirBasename -- if this condition is satisfied
                 then traverseThisSubdir rest -- True -> then this subdir will be traversed
                 else rest -- False -> else, this subdir will not be traversed
                ) -- how to fold this directory and its children, given its path
            (\_ _ (OPS.Relative path) (OPS.Basename fileBasename) _ft -> do
                  let parentDir = OsPath.takeDirectory path
                  set <- IORef.readIORef setRef
                  if not (S.member parentDir set) && collectPred fileBasename -- if this condition is satisfied
                  then do
                        IORef.writeIORef setRef $  S.insert parentDir set -- we add the parentDir of this file, to prevent adding more than 1 .cabal file
                        pure (Just path) -- True -> then this path will be added to the results
                  else pure Nothing -- False -> else, this path wont be added
                )
            (Identity root) -- (f a), list of roots to search in
  where
    visitCurrSubdirPred :: OsPath.OsPath -> Bool
    visitCurrSubdirPred d =
           d /= [OsPath.osp|dist|]
        && d /= [OsPath.osp|dist-newstyle|]
        && d /= [OsPath.osp|.stack-work|]
        && d /= [OsPath.osp|.git|]

    collectPred :: OsPath.OsPath -> Bool
    collectPred p =
        OsPath.takeExtension p == [OsPath.osp|.cabal|]

```

</p>
</details> 

And here is a comparison of the memory usage of the streaming implementation (right) vs. the ospath implementation (left) I posted on the other issue.

<img width="1421" alt="Screenshot 2025-04-16 at 12 46 40 p m" src="https://github.com/user-attachments/assets/1169e30b-7970-4258-b53d-43b83a18d84d" />

